### PR TITLE
🔧 add missing lerna bootstrap command

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -47,6 +47,8 @@
     "start": "node ./build/src/index.js",
     "watch": "tsc -w",
     "build": "tsc && npm run copy",
+    "bootstrap": "lerna bootstrap",
+    "heroku-postinstall": "npm run bootstrap",
     "heroku-postbuild": "npm run build && npm run migrate:latest",
     "exec": "ts-node --files"
   },


### PR DESCRIPTION
- add heroku-postinstall script to run lerna bootstrap
- fixes deployment issue