### PR TITLE
🔧 run migrations in release phase instead of postbuild

### DIFF
--- a/api/Procfile
+++ b/api/Procfile
@@ -1,1 +1,2 @@
 web: cd api && npm run start
+release: cd api && npm run migrate:latest

--- a/api/package.json
+++ b/api/package.json
@@ -47,7 +47,7 @@
     "start": "node ./build/src/index.js",
     "watch": "tsc -w",
     "build": "tsc && npm run copy",
-    "heroku-postbuild": "npm run build && npm run migrate:latest",
+    "heroku-postbuild": "npm run build",
     "exec": "ts-node --files"
   },
   "dependencies": {


### PR DESCRIPTION
as discussed on slack

https://devcenter.heroku.com/articles/release-phase