### PR TITLE
👷‍♀️ don't skip test coverage reporting on master

### DIFF
--- a/.travis/cc-report.sh
+++ b/.travis/cc-report.sh
@@ -5,8 +5,8 @@ if [ ! -f ./cc-test-reporter ]; then
   exit 1;
 fi
 
-if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-  echo "Skipping coverage uploads for PR build"
+if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" != "master" ]; then
+  echo "Skipping coverage uploads for push builds on $TRAVIS_BRANCH"
   exit 0;
 fi
 


### PR DESCRIPTION
Need to augment the condition so that we always report coverage on builds triggered on `master`, so that we get the reports on code-climate.