### PR TITLE
🐛 fix navbar path matching on path patterns

### DIFF
--- a/dashboard-app/src/navigation/Navbar/index.tsx
+++ b/dashboard-app/src/navigation/Navbar/index.tsx
@@ -39,11 +39,11 @@ const Title = styled.p`
  */
 const Navbar: React.FunctionComponent<Props> = (props) => {
   const currentPage = Pages.matchPath(props.pathname);
-  const isLoggedIn = currentPage.protected;
+  const isLoggedIn = currentPage ? currentPage.protected : false;
   const links = Pages.getProtected().map((page) => ({
     to: page.url,
     content: page.title,
-    active: page.url === currentPage.url,
+    active: page.url === (currentPage || { url: '' }).url,
   }));
 
   return(

--- a/dashboard-app/src/navigation/pages.ts
+++ b/dashboard-app/src/navigation/pages.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { matchPath } from 'react-router';
 import { Dictionary, filter } from 'ramda';
 import Dashboard from '../dashboard/Dashboard';
 import ByActivity from '../dashboard/ByActivity';
@@ -67,17 +68,22 @@ export const PagesDict: PagesDictionary = {
 };
 
 
-const filterBy = (k: keyof Page, v: string) => filter((page) => page[k] === v, PagesDict);
-
-
 export const Pages = {
   matchPath (pathname: string) {
-    const pages = filterBy('url', pathname);
+    const match = Object.values(PagesDict)
+      .map(({ url }) => matchPath(pathname, { path: url, exact: true }))
+      .filter(Boolean)
+      [0];
+
+    if (match === null || match === undefined) {
+      return null;
+    }
+
+    const pages = filter((page) => page.url === match.url, PagesDict);
     const keys = Object.keys(pages);
 
     if (keys.length !== 1) {
-      throw new Error(`One page expected, ${keys.length} returned: ${keys}. ${pathname}`);
-
+      return null;
     }
 
     return pages[keys[0]];


### PR DESCRIPTION
Discovered as part of QA

### Changes
* Use `react-router` provided path matching function to support path parameters
* Prevent the `matchPath` method from throwing (silent failure leading to empty navbar is probably less jarring for users, and therefore preferable.)