### PR TITLE
🐛 fix abbreviated month bug on firefox

### DIFF
--- a/dashboard-app/src/util/dataManipulation/aggregatedToTableData.ts
+++ b/dashboard-app/src/util/dataManipulation/aggregatedToTableData.ts
@@ -24,7 +24,6 @@ export const abbreviateDateString = (x: string): string => {
     ? `${numericalMonth}`
     : `0${numericalMonth}`;
   const isoDate = `${year}-${doubleDigitNumericalMonth}`;
-  console.log(isoDate);
   return moment(isoDate).format(Months.format.table);
 };
 

--- a/dashboard-app/src/util/dataManipulation/aggregatedToTableData.ts
+++ b/dashboard-app/src/util/dataManipulation/aggregatedToTableData.ts
@@ -18,7 +18,14 @@ export const isDateString = (x: any): boolean => {
 };
 
 export const abbreviateDateString = (x: string): string => {
-  return moment(new Date(x)).format(Months.format.table);
+  const [month, year] = x.split(' ');
+  const numericalMonth = Months.list.indexOf(month) + 1;
+  const doubleDigitNumericalMonth = numericalMonth > 9
+    ? `${numericalMonth}`
+    : `0${numericalMonth}`;
+  const isoDate = `${year}-${doubleDigitNumericalMonth}`;
+  console.log(isoDate);
+  return moment(isoDate).format(Months.format.table);
 };
 
 const abbreviateIfDateString = (x: any): string => isDateString(x) ? abbreviateDateString(x) : x;
@@ -48,3 +55,4 @@ export const aggregatedToTableData = ({ title, data }: Params) => {
     merge({ title })
     )(data as any) as DataTableProps;
 };
+


### PR DESCRIPTION
- create ISO string format before creating moment/date object

fixes #105