### PR TITLE
✨ add tab components

### DIFF
--- a/dashboard-app/src/components/Tabs/Tab.tsx
+++ b/dashboard-app/src/components/Tabs/Tab.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import styled from 'styled-components';
+
+
+/**
+ * Types
+ */
+type TabProps = {
+  isActive?: boolean
+  idx: number
+};
+
+/**
+ * Styles
+ */
+const TabContainer = styled.div`
+  display: ${(props: TabProps) => props.isActive ? 'inherit' : 'none'};
+`;
+
+
+export const Tab: React.FunctionComponent<TabProps> = (props) => {
+  const { children, ...rest } = props;
+  return (
+    <TabContainer {...rest}>
+      {children}
+    </TabContainer>
+  );
+};

--- a/dashboard-app/src/components/Tabs/TabGroup.tsx
+++ b/dashboard-app/src/components/Tabs/TabGroup.tsx
@@ -1,0 +1,41 @@
+import React, { useState, useCallback } from 'react';
+import styled from 'styled-components';
+import { TabList } from './TabList';
+import { Tab } from './Tab';
+
+
+/**
+ * Types
+ */
+type TabProps = {
+  titles: string[]
+  initialActiveTab?: number
+};
+
+/**
+ * Styles
+ */
+const TabContainer = styled.div``;
+
+export const TabGroup: React.FunctionComponent<TabProps> = (props) => {
+  const [activeTab, setActiveTab] = useState(0);
+
+  const onClickTab = useCallback(setActiveTab, []);
+
+  const children = React.Children.map(props.children, (child, idx) => (
+    <Tab isActive={idx === activeTab} idx={idx}>
+      {child}
+    </Tab>
+  ));
+
+  return (
+    <TabContainer>
+      <TabList
+        items={props.titles}
+        activeTab={activeTab}
+        onClickTab={onClickTab}
+      />
+      {children}
+    </TabContainer>
+  );
+};

--- a/dashboard-app/src/components/Tabs/TabGroup.tsx
+++ b/dashboard-app/src/components/Tabs/TabGroup.tsx
@@ -23,9 +23,13 @@ export const TabGroup: React.FunctionComponent<TabProps> = (props) => {
   const onClickTab = useCallback(setActiveTab, []);
 
   const children = React.Children.map(props.children, (child, idx) => (
-    <Tab isActive={idx === activeTab} idx={idx}>
-      {child}
-    </Tab>
+    idx === activeTab
+      ? (
+        <Tab isActive idx={idx}>
+          {child}
+        </Tab>
+      )
+      : null
   ));
 
   return (

--- a/dashboard-app/src/components/Tabs/TabGroup.tsx
+++ b/dashboard-app/src/components/Tabs/TabGroup.tsx
@@ -18,7 +18,8 @@ type TabProps = {
 const TabContainer = styled.div``;
 
 export const TabGroup: React.FunctionComponent<TabProps> = (props) => {
-  const [activeTab, setActiveTab] = useState(0);
+  const { initialActiveTab = 0 } = props;
+  const [activeTab, setActiveTab] = useState(initialActiveTab);
 
   const onClickTab = useCallback(setActiveTab, []);
 

--- a/dashboard-app/src/components/Tabs/TabList.tsx
+++ b/dashboard-app/src/components/Tabs/TabList.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styled from 'styled-components';
+import { rgba } from 'polished';
+import { TabListItem } from './TabListItem';
+import { ColoursEnum } from '../../styles/design_system';
+
+
+/**
+ * Types
+ */
+type TabListProps = {
+  items: string[]
+  activeTab: number
+  onClickTab?: (n: number) => void
+};
+
+
+/**
+ * Styles
+ */
+const List = styled.ol`
+  list-style: none;
+  display: flex;
+  border-bottom: 1px solid ${rgba(ColoursEnum.grey, 0.4)};
+`;
+
+export const TabList: React.FunctionComponent<TabListProps> = (props) => {
+  const {
+    items,
+    activeTab,
+    onClickTab = () => {},
+  } = props;
+
+  return (
+    <List>
+      {
+        items.map((item, idx) => (
+          <TabListItem
+            title={item}
+            isActive={idx === activeTab}
+            onClick={() => onClickTab(idx)}
+          />
+        ))
+      }
+    </List>
+  );
+};

--- a/dashboard-app/src/components/Tabs/TabList.tsx
+++ b/dashboard-app/src/components/Tabs/TabList.tsx
@@ -39,6 +39,7 @@ export const TabList: React.FunctionComponent<TabListProps> = (props) => {
             title={item}
             isActive={idx === activeTab}
             onClick={() => onClickTab(idx)}
+            key={item}
           />
         ))
       }

--- a/dashboard-app/src/components/Tabs/TabListItem.tsx
+++ b/dashboard-app/src/components/Tabs/TabListItem.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import styled from 'styled-components';
+import { ColoursEnum } from '../../styles/design_system';
+
+
+/**
+ * Types
+ */
+type TabListItemProps = {
+  title: string
+  isActive?: boolean
+  onClick: (a: any) => void
+};
+
+
+/**
+ * Styles
+ */
+const Item = styled.li`
+  padding: 1rem;
+  ${
+    (props: Pick<TabListItemProps, 'isActive'>) => props.isActive
+      ? `border-bottom: 2px solid ${ColoursEnum.darkGrey};`
+      : ''
+  }
+`;
+
+
+/**
+ * Component
+ */
+export const TabListItem: React.FunctionComponent<TabListItemProps> = (props) => {
+  const {
+    title,
+    isActive = false,
+    onClick = () => {},
+  } = props;
+
+  return (
+    <Item onClick={onClick} isActive={isActive}>
+      {title}
+    </Item>
+  );
+};

--- a/dashboard-app/src/components/Tabs/__tests__/TabGroup.test.tsx
+++ b/dashboard-app/src/components/Tabs/__tests__/TabGroup.test.tsx
@@ -7,9 +7,32 @@ import 'jest-dom/extend-expect';
 describe('TabGroup', () => {
   afterEach(cleanup);
 
-  test('empty TabGroup', async () => {
-    const tools = render(<TabGroup titles={[]} />);
+  test('renders first tab by default', async () => {
+    expect.assertions(2);
 
+    const tools = render(
+      <TabGroup titles={['one', 'two']}>
+        <div>
+          This is the first tab content
+        </div>
+        <div>
+          This is the second tab content
+        </div>
+      </TabGroup>
+    );
 
+    const tabContent = await waitForElement(() => tools.getByText('This is the first tab content'));
+    const findSecondTab = async () =>
+      await waitForElement(() => tools.getByText('This is the second tab content'))
+
+    expect(tabContent).toHaveTextContent('This is the first tab content');
+
+    try {
+      await findSecondTab();
+    } catch (error) {
+      expect(error.message
+        .includes('Unable to find an element with the text: This is the second tab content.')
+      ).toBe(true);
+    }
   });
 });

--- a/dashboard-app/src/components/Tabs/__tests__/TabGroup.test.tsx
+++ b/dashboard-app/src/components/Tabs/__tests__/TabGroup.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { cleanup, render, waitForElement, fireEvent } from 'react-testing-library';
+import { TabGroup } from '../TabGroup';
+import 'jest-dom/extend-expect';
+
+
+describe('TabGroup', () => {
+  test('', async () => {});
+});

--- a/dashboard-app/src/components/Tabs/__tests__/TabGroup.test.tsx
+++ b/dashboard-app/src/components/Tabs/__tests__/TabGroup.test.tsx
@@ -5,34 +5,85 @@ import 'jest-dom/extend-expect';
 
 
 describe('TabGroup', () => {
+  const TabOne = {
+    title: 'one',
+    text: 'This is the first tab content',
+    content: () => <div>{TabOne.text}</div>,
+  };
+  const TabTwo = {
+    title: 'two',
+    text: 'This is the second tab content',
+    content: () => <div>{TabTwo.text}</div>,
+  };
+  type Args = { shown: typeof TabOne, hidden: typeof TabOne, ctx: any };
+  const makeTabAssertions = async ({ shown, hidden, ctx }: Args) => {
+    const tabContent =
+    await waitForElement(() => ctx.getByText(shown.text));
+    const findOtherTab = async () =>
+      await waitForElement(() => ctx.getByText(hidden.text), { timeout: 500 });
+
+    expect(tabContent).toHaveTextContent(shown.text);
+
+    try {
+      await findOtherTab();
+    } catch (error) {
+      expect(error.message
+        .includes(`Unable to find an element with the text: ${hidden.text}.`)
+      ).toBe(true);
+    }
+  };
+
   afterEach(cleanup);
 
   test('renders first tab by default', async () => {
     expect.assertions(2);
 
     const tools = render(
-      <TabGroup titles={['one', 'two']}>
-        <div>
-          This is the first tab content
-        </div>
-        <div>
-          This is the second tab content
-        </div>
+      <TabGroup titles={[TabOne.title, TabTwo.title]}>
+        {TabOne.content()}
+        {TabTwo.content()}
       </TabGroup>
     );
 
-    const tabContent = await waitForElement(() => tools.getByText('This is the first tab content'));
-    const findSecondTab = async () =>
-      await waitForElement(() => tools.getByText('This is the second tab content'))
+    await makeTabAssertions({ shown: TabOne, hidden: TabTwo, ctx: tools });
+  });
 
-    expect(tabContent).toHaveTextContent('This is the first tab content');
+  test('renders tab based on prop', async () => {
+    expect.assertions(2);
 
-    try {
-      await findSecondTab();
-    } catch (error) {
-      expect(error.message
-        .includes('Unable to find an element with the text: This is the second tab content.')
-      ).toBe(true);
-    }
+    const tools = render(
+      <TabGroup titles={[TabOne.title, TabTwo.title]} initialActiveTab={1}>
+        {TabOne.content()}
+        {TabTwo.content()}
+      </TabGroup>
+    );
+
+    await makeTabAssertions({ shown: TabTwo, hidden: TabOne, ctx: tools });
+  });
+
+  test('select tab to render on click', async () => {
+    expect.assertions(6);
+
+    const tools = render(
+      <TabGroup titles={[TabOne.title, TabTwo.title]}>
+        {TabOne.content()}
+        {TabTwo.content()}
+      </TabGroup>
+    );
+
+    const [tabOne, tabTwo] = await waitForElement(() => [
+      tools.getByText('one'),
+      tools.getByText('two'),
+    ]);
+
+    await makeTabAssertions({ shown: TabOne, hidden: TabTwo, ctx: tools });
+
+    fireEvent.click(tabTwo);
+
+    await makeTabAssertions({ shown: TabTwo, hidden: TabOne, ctx: tools });
+
+    fireEvent.click(tabOne);
+
+    await makeTabAssertions({ shown: TabOne, hidden: TabTwo, ctx: tools });
   });
 });

--- a/dashboard-app/src/components/Tabs/__tests__/TabGroup.test.tsx
+++ b/dashboard-app/src/components/Tabs/__tests__/TabGroup.test.tsx
@@ -5,5 +5,11 @@ import 'jest-dom/extend-expect';
 
 
 describe('TabGroup', () => {
-  test('', async () => {});
+  afterEach(cleanup);
+
+  test('empty TabGroup', async () => {
+    const tools = render(<TabGroup titles={[]} />);
+
+
+  });
 });

--- a/dashboard-app/src/components/Tabs/index.tsx
+++ b/dashboard-app/src/components/Tabs/index.tsx
@@ -1,0 +1,2 @@
+export { TabGroup } from './TabGroup';
+export { Tab } from './Tab';


### PR DESCRIPTION
Fixes #121 

### Changes
* Add `TabGroup` component (and sub-components)	based on designs
* Add tests

Usage example:
```
<TabGroup titles={[TABLE_TITLE, 'Some other table']}>
  <DataTable
    {...tableData}
    title={TABLE_TITLE}
    sortBy={sortBy}
    initialOrder="desc"
    onChangeSortBy={onChangeSortBy}
    showTotals
  />
  <DataTable
    {...tableData}
    title={"Some other table"}
    sortBy={sortBy}
    initialOrder="desc"
    onChangeSortBy={onChangeSortBy}
    showTotals
  />
</TabGroup>
```