### PR TITLE
🐛 fix bug by tracking sorted column by index instead of title

### DIFF
--- a/dashboard-app/src/dashboard/ByActivity/__tests__/index.test.ts
+++ b/dashboard-app/src/dashboard/ByActivity/__tests__/index.test.ts
@@ -1,18 +1,29 @@
-import { cleanup } from 'react-testing-library';
+import { cleanup, waitForElement } from 'react-testing-library';
+import MockAdapter from 'axios-mock-adapter';
 import { renderWithHistory } from '../../../util/tests';
+import { axios } from '../../../api';
 import ByActivity from '..';
 import 'jest-dom/extend-expect';
 
 describe('By Activity Page', () => {
-  beforeEach(cleanup);
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(axios);
+  });
 
   afterEach(cleanup);
 
   test('Success :: Display Title', async () => {
     expect.assertions(1);
+
+    mock.onGet('/community-businesses/me/volunteer-logs').reply(200, { result: [] });
+    mock.onGet('/community-businesses/me/volunteers').reply(200, { result: [] });
+    mock.onGet('/volunteer-activities').reply(200, { result: [] });
+
     const tools = renderWithHistory(ByActivity);
 
-    const title = await tools.getByText('By', { exact: false });
+    const title = await waitForElement(() => tools.getByText('By', { exact: false }));
 
     expect(title.textContent).toEqual('By Activity');
   });

--- a/dashboard-app/src/dashboard/ByTime/__tests__/index.test.ts
+++ b/dashboard-app/src/dashboard/ByTime/__tests__/index.test.ts
@@ -1,18 +1,27 @@
-import { cleanup } from 'react-testing-library';
+import { cleanup, waitForElement } from 'react-testing-library';
+import MockAdapter from 'axios-mock-adapter';
 import { renderWithHistory } from '../../../util/tests';
+import { axios } from '../../../api';
 import ByTime from '..';
 import 'jest-dom/extend-expect';
 
 describe('By Activity Page', () => {
-  beforeEach(cleanup);
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(axios);
+  });
 
   afterEach(cleanup);
 
   test('Success :: Display Title', async () => {
     expect.assertions(1);
+
+    mock.onGet('/community-businesses/me/volunteer-logs').reply(200, { result: [] });
+
     const tools = renderWithHistory(ByTime);
 
-    const title = await tools.getByText('By', { exact: false });
+    const title = await waitForElement(() => tools.getByText('By', { exact: false }));
 
     expect(title.textContent).toEqual('By Time');
   });

--- a/dashboard-app/src/dashboard/ByVolunteer/__tests__/index.test.ts
+++ b/dashboard-app/src/dashboard/ByVolunteer/__tests__/index.test.ts
@@ -1,18 +1,28 @@
-import { cleanup } from 'react-testing-library';
+import { cleanup, waitForElement } from 'react-testing-library';
+import MockAdapter from 'axios-mock-adapter';
 import { renderWithHistory } from '../../../util/tests';
+import { axios } from '../../../api';
 import ByVolunteer from '..';
 import 'jest-dom/extend-expect';
 
 describe('By Activity Page', () => {
-  beforeEach(cleanup);
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(axios);
+  });
 
   afterEach(cleanup);
 
   test('Success :: Display Title', async () => {
     expect.assertions(1);
+
+    mock.onGet('/community-businesses/me/volunteer-logs').reply(200, { result: [] });
+    mock.onGet('/community-businesses/me/volunteers').reply(200, { result: [] });
+
     const tools = renderWithHistory(ByVolunteer);
 
-    const title = await tools.getByText('By', { exact: false });
+    const title = await waitForElement(() => tools.getByText('By', { exact: false }));
 
     expect(title.textContent).toEqual('By Volunteer');
   });


### PR DESCRIPTION
Fixes #128 

### Changes
* `sortBy` state fragment tracks column index (`number`) instead of column name (`string`) since the latter is not fixed but the former is
* Use default empty initial state for `tableData` so components don't have to deal with the null case
* Render loader while data is being fetched to avoid rendering `NO DATA AVAILABLE` view unnecessarily

Note:
I think the hooks should be refactored to allow this all to happen a little more easily and with quite so much boilerplate. We can certainly build some higher-level hooks on top of the ones we already have. However I decided not to do this in this PR in the interests of getting things through QA more quickly. I think we should do it this sprint though.