### PR TITLE
🐛 limit concurrent queries by replacing Promise.all with Promises.series

### DIFF
--- a/api/src/models/visitor.ts
+++ b/api/src/models/visitor.ts
@@ -3,7 +3,7 @@
  */
 import { createHmac, randomBytes } from 'crypto';
 import { assoc, omit, pick, evolve, compose, pipe, filter } from 'ramda';
-import { Objects } from 'twine-util';
+import { Objects, Promises } from 'twine-util';
 import { Map } from '../types/internal';
 import { User, VisitorCollection, LinkedVisitEvent, RoleEnum } from './types';
 import { Users, ModelToColumn } from './user';
@@ -185,7 +185,7 @@ export const Visitors: VisitorCollection = {
       query
     );
 
-    const userVisits: LinkedVisitEvent[][] = await Promise.all(rows.map((user) =>
+    const userVisits: LinkedVisitEvent[][] = await Promises.series(rows.map((user) =>
       client
         .select(additionalColumnMap)
         .from('visit_log')

--- a/lib/twine-util/__tests__/promises.test.ts
+++ b/lib/twine-util/__tests__/promises.test.ts
@@ -34,6 +34,18 @@ describe('Utilities :: Promises', () => {
       then.mock.calls[1][0]((a: number) => expect(a).toBe(1));
       then.mock.calls[2][0]((a: number) => expect(a).toBe(2));
     });
+
+    test('Does not flatten results', async () => {
+      const ps = [
+        Promise.resolve([1]),
+        Promise.resolve([2]),
+        Promise.resolve([3]),
+      ];
+
+      const xs = await Promises.series(ps);
+
+      expect(xs).toEqual([[1], [2], [3]]);
+    });
   });
 
   describe('fromStream', () => {

--- a/lib/twine-util/promises.ts
+++ b/lib/twine-util/promises.ts
@@ -6,7 +6,7 @@ import * as stream from 'stream';
 
 export const series = <T>(ps: PromiseLike<T>[]): Promise<T[]> =>
   ps.reduce(
-    (fp, p) => fp.then((res) => p.then((rp) => res.concat(rp))),
+    (fp, p) => fp.then((res) => p.then((rp) => res.concat(Array.isArray(rp) ? [rp] : rp))),
     Promise.resolve([])
   );
 


### PR DESCRIPTION
Related to #136
Related to #123 

Only merge this if #136 proves insufficient in resolving #123