### PR TITLE
🐛 Minor fixes for dashboard charts

### DIFF
--- a/dashboard-app/src/components/Errors.tsx
+++ b/dashboard-app/src/components/Errors.tsx
@@ -9,10 +9,10 @@ import { ColoursEnum, SpacingEnum } from '../styles/design_system';
 /*
  * Types
  */
-
 interface Props {
   errors: Dictionary<string>;
 }
+
 
 /*
  * Styles
@@ -27,11 +27,18 @@ export const ErrorParagraph = styled.p`
 /*
  * Component
  */
-const Errors: FunctionComponent<Props> = (props) =>
-  (<Row center="xs">
-    <Col>
-      <ErrorParagraph>{toPairs(props.errors).map((x) => x.join(': ')) || ''}</ErrorParagraph>
-    </Col>
-</Row>);
+const Errors: FunctionComponent<Props> = ({ errors }) => {
+  if (Object.keys(errors).length === 0) {
+    return null;
+  }
+
+  return (
+    <Row center="xs">
+      <Col>
+        <ErrorParagraph>{toPairs(errors).map((x) => x.join(': ')) || ''}</ErrorParagraph>
+      </Col>
+    </Row>
+  );
+};
 
 export default Errors;

--- a/dashboard-app/src/components/StackedBarChart/index.tsx
+++ b/dashboard-app/src/components/StackedBarChart/index.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { Row, Col } from 'react-flexbox-grid';
-import { Bar } from 'react-chartjs-2';
+import { Bar, ChartComponentProps } from 'react-chartjs-2';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 
 
@@ -17,7 +17,7 @@ import { ColoursEnum } from '../../styles/design_system';
  */
 
 interface Props {
-  data: any;
+  data: ChartComponentProps['data'];
   xAxisTitle: string;
   yAxisTitle: string;
   title: string;

--- a/dashboard-app/src/dashboard/ByActivity/index.tsx
+++ b/dashboard-app/src/dashboard/ByActivity/index.tsx
@@ -80,6 +80,8 @@ const ByActivity: FunctionComponent<RouteComponentProps> = (props) => {
   const downloadAsCsv = useCallback(() => {
     if (!loading && data) {
       downloadCsv({ data, fromDate, toDate, setErrors, fileName: 'by_activity', unit });
+    } else {
+      setErrors({ Download: 'No data available to download' });
     }
   }, [data, fromDate, toDate, unit]);
 

--- a/dashboard-app/src/dashboard/ByActivity/index.tsx
+++ b/dashboard-app/src/dashboard/ByActivity/index.tsx
@@ -16,6 +16,7 @@ import { ColoursEnum } from '../../styles/design_system';
 import Errors from '../../components/Errors';
 import useAggregateDataByActivity from '../hooks/useAggregateDataByActivity';
 import { TabGroup } from '../../components/Tabs';
+import { Dictionary } from 'ramda';
 
 
 /**
@@ -54,7 +55,7 @@ const ByActivity: FunctionComponent<RouteComponentProps> = (props) => {
   const [fromDate, setFromDate] = useState<Date>(DatePickerConstraints.from.default());
   const [toDate, setToDate] = useState<Date>(DatePickerConstraints.to.default());
   const [tableData, setTableData] = useState<TableData>(initTableData);
-  const [errors, setErrors] = useState();
+  const [errors, setErrors] = useState<Dictionary<string>>({});
   const { loading, error, data } = useAggregateDataByActivity({ from: fromDate, to: toDate });
 
   useEffect(() => {

--- a/dashboard-app/src/dashboard/ByTime/index.tsx
+++ b/dashboard-app/src/dashboard/ByTime/index.tsx
@@ -17,6 +17,7 @@ import TimeTabs from './TimeTabs';
 import Errors from '../../components/Errors';
 import useAggregateDataByTime from '../hooks/useAggregateDataByTime';
 import Months from '../../util/months';
+import { Dictionary } from 'ramda';
 
 
 /**
@@ -45,7 +46,7 @@ const ByTime: FunctionComponent<RouteComponentProps> = (props) => {
   const [sortBy, setSortBy] = useState(0);
   const [fromDate, setFromDate] = useState<Date>(DatePickerConstraints.from.default());
   const [toDate, setToDate] = useState<Date>(DatePickerConstraints.to.default());
-  const [errors, setErrors] = useState();
+  const [errors, setErrors] = useState<Dictionary<string>>({});
   const [tableData, setTableData] = useState<TableData>(initTableData);
   const { data, loading, error } = useAggregateDataByTime({ from: fromDate, to: toDate });
 
@@ -78,7 +79,7 @@ const ByTime: FunctionComponent<RouteComponentProps> = (props) => {
   }, [data, fromDate, toDate, unit]);
 
   const tabProps = {
-    data,
+    data: data || { headers: [], rows: [] },
     unit,
     tableData,
     sortBy,

--- a/dashboard-app/src/dashboard/ByTime/index.tsx
+++ b/dashboard-app/src/dashboard/ByTime/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useCallback, FunctionComponent } from 'react';
 import styled from 'styled-components';
+import moment from 'moment';
 import { withRouter, RouteComponentProps } from 'react-router';
 import { Grid, Row, Col } from 'react-flexbox-grid';
 
@@ -15,6 +16,7 @@ import { ColoursEnum } from '../../styles/design_system';
 import TimeTabs from './TimeTabs';
 import Errors from '../../components/Errors';
 import useAggregateDataByTime from '../hooks/useAggregateDataByTime';
+import Months from '../../util/months';
 
 
 /**
@@ -30,9 +32,10 @@ const Container = styled(Grid)`
 /**
  * Helpers
  */
-const TITLE = 'Volunteer Activity over Months';
 const initTableData = { headers: [], rows: [] };
-
+const getTitle = (from: Date, to: Date) =>
+  `Volunteer Activity per month: \
+    ${moment(from).format(Months.format.table)} - ${moment(to).format(Months.format.table)}`;
 
 /**
  * Component
@@ -70,7 +73,14 @@ const ByTime: FunctionComponent<RouteComponentProps> = (props) => {
     downloadCsv({ data, fromDate, toDate, setErrors, fileName: 'by_activity', unit });
   }, [data, fromDate, toDate, unit]);
 
-  const tabProps = { data, unit, tableData, sortBy, onChangeSortBy, title: TITLE };
+  const tabProps = {
+    data,
+    unit,
+    tableData,
+    sortBy,
+    onChangeSortBy,
+    title: getTitle(fromDate, toDate),
+  };
 
   return (
     <Container>

--- a/dashboard-app/src/dashboard/ByTime/index.tsx
+++ b/dashboard-app/src/dashboard/ByTime/index.tsx
@@ -70,7 +70,11 @@ const ByTime: FunctionComponent<RouteComponentProps> = (props) => {
   }, [tableData]);
 
   const downloadAsCsv = useCallback(() => {
-    downloadCsv({ data, fromDate, toDate, setErrors, fileName: 'by_activity', unit });
+    if (!loading && data) {
+      downloadCsv({ data, fromDate, toDate, setErrors, fileName: 'by_activity', unit });
+    } else {
+      setErrors({ Download: 'No data available to download' });
+    }
   }, [data, fromDate, toDate, unit]);
 
   const tabProps = {

--- a/dashboard-app/src/dashboard/ByTime/index.tsx
+++ b/dashboard-app/src/dashboard/ByTime/index.tsx
@@ -57,7 +57,7 @@ const ByTime: FunctionComponent<RouteComponentProps> = (props) => {
 
   // manipulate data for table
   useEffect(() => {
-    if (data) {
+    if (!loading && data) {
       setTableData(aggregatedToTableData({ data, unit }));
     }
   }, [data, unit]);

--- a/dashboard-app/src/dashboard/ByVolunteer/index.tsx
+++ b/dashboard-app/src/dashboard/ByVolunteer/index.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useCallback, FunctionComponent } from 'react';
+import moment from 'moment';
+import styled from 'styled-components';
 import { withRouter, RouteComponentProps } from 'react-router';
 import { Grid, Row, Col } from 'react-flexbox-grid';
-import styled from 'styled-components';
 
 import DatePickerConstraints from './datePickerConstraints';
 import UtilityBar from '../../components/UtilityBar';
@@ -14,6 +15,7 @@ import { ColoursEnum } from '../../styles/design_system';
 import VolunteerTabs from './VolunteerTabs';
 import Errors from '../../components/Errors';
 import useAggregateDataByVolunteer from '../hooks/useAggregateDataByVolunteer';
+import Months from '../../util/months';
 
 
 /**
@@ -29,8 +31,10 @@ const Container = styled(Grid)`
 /**
  * Helpers
  */
-const TITLE = 'Volunteer Time per Month';
 const initTableData = { headers: [], rows: [] };
+const getTitle = (from: Date, to: Date) =>
+  `Volunteer Time per month: \
+    ${moment(from).format(Months.format.table)} - ${moment(to).format(Months.format.table)}`;
 
 
 /**
@@ -69,7 +73,14 @@ const ByVolunteer: FunctionComponent<RouteComponentProps> = (props) => {
     downloadCsv({ data, fromDate, toDate, setErrors, fileName: 'by_activity', unit });
   }, [data, fromDate, toDate, unit]);
 
-  const tabProps = { data, unit, tableData, sortBy, onChangeSortBy, title: TITLE };
+  const tabProps = {
+    data,
+    unit,
+    tableData,
+    sortBy,
+    onChangeSortBy,
+    title: getTitle(fromDate, toDate),
+  };
 
   return (
     <Container>

--- a/dashboard-app/src/dashboard/ByVolunteer/index.tsx
+++ b/dashboard-app/src/dashboard/ByVolunteer/index.tsx
@@ -70,7 +70,11 @@ const ByVolunteer: FunctionComponent<RouteComponentProps> = (props) => {
   }, [tableData]);
 
   const downloadAsCsv = useCallback(() => {
-    downloadCsv({ data, fromDate, toDate, setErrors, fileName: 'by_activity', unit });
+    if (!loading && data) {
+      downloadCsv({ data, fromDate, toDate, setErrors, fileName: 'by_activity', unit });
+    } else {
+      setErrors({ Download: 'No data available to download' });
+    }
   }, [data, fromDate, toDate, unit]);
 
   const tabProps = {

--- a/dashboard-app/src/dashboard/ByVolunteer/index.tsx
+++ b/dashboard-app/src/dashboard/ByVolunteer/index.tsx
@@ -57,7 +57,7 @@ const ByVolunteer: FunctionComponent<RouteComponentProps> = (props) => {
 
   // manipulate data for table
   useEffect(() => {
-    if (data) {
+    if (!loading && data) {
       setTableData(aggregatedToTableData({ data, unit }));
     }
   }, [data, unit]);

--- a/dashboard-app/src/dashboard/ByVolunteer/index.tsx
+++ b/dashboard-app/src/dashboard/ByVolunteer/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, FunctionComponent } from 'react';
 import moment from 'moment';
 import styled from 'styled-components';
+import { Dictionary } from 'ramda';
 import { withRouter, RouteComponentProps } from 'react-router';
 import { Grid, Row, Col } from 'react-flexbox-grid';
 
@@ -46,7 +47,7 @@ const ByVolunteer: FunctionComponent<RouteComponentProps> = (props) => {
   const [fromDate, setFromDate] = useState<Date>(DatePickerConstraints.from.default());
   const [toDate, setToDate] = useState<Date>(DatePickerConstraints.to.default());
   const [tableData, setTableData] = useState<TableData>(initTableData);
-  const [errors, setErrors] = useState();
+  const [errors, setErrors] = useState<Dictionary<string>>({});
   const { loading, data, error } = useAggregateDataByVolunteer({ from: fromDate, to: toDate });
 
   useEffect(() => {
@@ -78,7 +79,7 @@ const ByVolunteer: FunctionComponent<RouteComponentProps> = (props) => {
   }, [data, fromDate, toDate, unit]);
 
   const tabProps = {
-    data,
+    data: data || { headers: [], rows: [] },
     unit,
     tableData,
     sortBy,

--- a/dashboard-app/src/dashboard/hooks/useAggregateDataByActivity.ts
+++ b/dashboard-app/src/dashboard/hooks/useAggregateDataByActivity.ts
@@ -1,7 +1,7 @@
 import { DependencyList, useEffect, useState } from 'react';
 import { useBatchRequest } from '../../hooks';
 import { CommunityBusinesses } from '../../api';
-import { logsToAggregatedData } from '../dataManipulation/logsToAggregatedData';
+import { logsToAggregatedData, AggregatedData } from '../dataManipulation/logsToAggregatedData';
 import { tableType } from '../dataManipulation/tableType';
 
 
@@ -12,7 +12,7 @@ interface UseAggregatedDataParams {
 }
 
 export default ({ from, to, updateOn = [] }: UseAggregatedDataParams) => {
-  const [aggregatedData, setAggregatedData] = useState();
+  const [aggregatedData, setAggregatedData] = useState<AggregatedData>({ rows: [], headers: [] });
 
   const {
     loading,

--- a/dashboard-app/src/dashboard/hooks/useAggregateDataByTime.ts
+++ b/dashboard-app/src/dashboard/hooks/useAggregateDataByTime.ts
@@ -1,7 +1,7 @@
 import { DependencyList, useEffect, useState } from 'react';
 import { useBatchRequest } from '../../hooks';
 import { CommunityBusinesses } from '../../api';
-import { logsToAggregatedData } from '../dataManipulation/logsToAggregatedData';
+import { logsToAggregatedData, AggregatedData } from '../dataManipulation/logsToAggregatedData';
 import { tableType } from '../dataManipulation/tableType';
 import Months from '../../util/months';
 
@@ -13,7 +13,7 @@ interface UseAggregatedDataParams {
 }
 
 export default ({ from, to, updateOn = [] }: UseAggregatedDataParams) => {
-  const [aggregatedData, setAggregatedData] = useState();
+  const [aggregatedData, setAggregatedData] = useState<AggregatedData>({ rows: [], headers: [] });
 
   const {
     loading,

--- a/dashboard-app/src/dashboard/hooks/useAggregateDataByVolunteer.ts
+++ b/dashboard-app/src/dashboard/hooks/useAggregateDataByVolunteer.ts
@@ -1,7 +1,7 @@
 import { DependencyList, useEffect, useState } from 'react';
 import { useBatchRequest } from '../../hooks';
 import { CommunityBusinesses } from '../../api';
-import { logsToAggregatedData } from '../dataManipulation/logsToAggregatedData';
+import { logsToAggregatedData, AggregatedData } from '../dataManipulation/logsToAggregatedData';
 import { tableType } from '../dataManipulation/tableType';
 import Months from '../../util/months';
 
@@ -13,7 +13,7 @@ interface UseAggregatedDataParams {
 }
 
 export default ({ from, to, updateOn = [] }: UseAggregatedDataParams) => {
-  const [aggregatedData, setAggregatedData] = useState();
+  const [aggregatedData, setAggregatedData] = useState<AggregatedData>({ rows: [], headers: [] });
 
   const {
     loading,

--- a/dashboard-app/src/util/months.ts
+++ b/dashboard-app/src/util/months.ts
@@ -3,7 +3,7 @@ import moment from 'moment';
 interface Months {
   list: string [];
   format: typeof MonthsFormatEnum;
-  range: (from: Date, to: Date, format: MonthsFormatEnum) => string [];
+  range: (from: Date, to: Date, format: MonthsFormatEnum) => string[];
   diff: (from: Date, to: Date) => number;
 }
 


### PR DESCRIPTION
Related to #130 

* Append active date filter to chart and table titles on Volunteer and Time pages (not specified on Activity page, plus date is a different format)
* ~~Add "NO DATA AVAILABLE" view to chart~~ **REMOVED TO AVOID CONFLICTS WITH @astroash**
* Minor formatting and type tidying

### Recommendations
I think we should do the following, and can either include them in this PR, or make issues and we can work on them afterwards:
1. More unified interface for `AggregatedData` related things
   * Single `AggregatedData` namespace exposed via `index.ts` file
   * `AggregatedData.fromLogs()`, `AggregatedData.toTableData()`, `AggregatedData.empty()`, `AggregatedData.AggregatedData` (type) etc.
2. Any reason that graph data is computed inside the `<X>Tabs.tsx` component but `TableData` is computed and stored in the page component? In favour of moving both to `<X>Tabs.tsx`.
3. Custom generic hook to give download functionality