### PR TITLE
💄 Add bar chart with rounded tops

### DIFF
--- a/dashboard-app/src/components/StackedBarChart/Chart.tsx
+++ b/dashboard-app/src/components/StackedBarChart/Chart.tsx
@@ -1,10 +1,11 @@
 import React, { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { Row, Col } from 'react-flexbox-grid';
-import { Bar, ChartData } from 'react-chartjs-2';
+import { ChartData } from 'react-chartjs-2';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import * as chartjs from 'chart.js';
 
+import RoundedBar from './RoundedBar';
 import { getStackedGraphOptions, totalizer } from './utils/chartjsUtils';
 import _Card from '../Card';
 import { H3 } from '../Headings';
@@ -56,7 +57,7 @@ const Chart: FunctionComponent<Props> = (props) => {
       </Row>
       <Row center="xs" middle="xs">
         <Col xs={12} md={9}>
-        <Bar
+        <RoundedBar
           datasetKeyProvider={datasetKeyProvider}
           plugins={[totalizer, ChartDataLabels]}
           data={data}

--- a/dashboard-app/src/components/StackedBarChart/RoundedBar/Rectangles.ts
+++ b/dashboard-app/src/components/StackedBarChart/RoundedBar/Rectangles.ts
@@ -1,0 +1,105 @@
+import { PositionType } from 'chart.js';
+
+
+export interface Rectangle {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  width: number;
+  absWidth: number;
+  height: number;
+  absHeight: number;
+}
+
+export type Corner = {
+  x: number
+  y: number
+};
+
+export type Corners = Corner[];
+
+
+export const Rectangles = {
+  init: (left: number, right: number, top: number, bottom: number): Rectangle => ({
+    left,
+    right,
+    top,
+    bottom,
+    get width () {
+      return right - left;
+    },
+    get absWidth () {
+      return Math.abs(right - left);
+    },
+    get height () {
+      return bottom - top;
+    },
+    get absHeight () {
+      return Math.abs(top - bottom);
+    },
+  }),
+
+  // Border width should be less than bar width and bar height
+  adjustBorderWidth: (borderWidth: number, r: Rectangle) =>
+    Math.min(r.absWidth, r.absHeight, borderWidth),
+
+  adjustByBorder: (borderSkipped: PositionType, borderWidth: number, r: Rectangle) => {
+    // Canvas doesn't allow us to stroke inside the width so we can
+    // adjust the sizes to fit if we're setting a stroke on the line
+    if (borderWidth) {
+      const signX = 1;
+      const signY = r.bottom > r.top ? 1 : -1;
+      const halfStroke = borderWidth / 2;
+
+      // Adjust borderWidth when bar top position is near vm.base(zero).
+      const borderLeft = r.left + (borderSkipped !== 'left' ? halfStroke * signX : 0);
+      const borderRight = r.right + (borderSkipped !== 'right' ? -halfStroke * signX : 0);
+      const borderTop = r.top + (borderSkipped !== 'top' ? halfStroke * signY : 0);
+      const borderBottom = r.bottom + (borderSkipped !== 'bottom' ? -halfStroke * signY : 0);
+
+      // not become a vertical line?
+      const isVerticalLine = borderLeft === borderRight;
+      const isHorizontalLine = borderTop === borderBottom;
+
+      return Rectangles.init(
+        !isHorizontalLine ? borderLeft : r.left,
+        !isHorizontalLine ? borderRight : r.right,
+        !isVerticalLine ? borderTop : r.top,
+        !isVerticalLine ? borderBottom : r.bottom
+      );
+    } else {
+      return { ...r };
+    }
+  },
+};
+
+export const Corners = {
+  init: (x: number, y: number) => ({ x, y }),
+
+  fromRectangle: (r: Rectangle): Corners => {
+    // Corner points, from bottom-left to bottom-right clockwise
+    // | 1 2 |
+    // | 0 3 |
+    return [
+      Corners.init(r.left, r.bottom),
+      Corners.init(r.left, r.top),
+      Corners.init(r.right, r.top),
+      Corners.init(r.right, r.bottom),
+    ];
+  },
+
+  selectByPosition: (p: PositionType, cs: Corners) => {
+    switch (p) {
+      case 'left':
+        return cs[1];
+      case 'top':
+        return cs[2];
+      case 'right':
+        return cs[3];
+      case 'bottom':
+      default:
+        return cs[0];
+    }
+  },
+};

--- a/dashboard-app/src/components/StackedBarChart/RoundedBar/Rectangles.ts
+++ b/dashboard-app/src/components/StackedBarChart/RoundedBar/Rectangles.ts
@@ -42,7 +42,7 @@ export const Rectangles = {
 
   // Border width should be less than bar width and bar height
   adjustBorderWidth: (borderWidth: number, r: Rectangle) =>
-    Math.min(r.absWidth, r.absHeight, borderWidth),
+    Math.min(r.absWidth, r.absHeight, Math.max(0, borderWidth)),
 
   adjustByBorder: (borderSkipped: PositionType, borderWidth: number, r: Rectangle) => {
     // Canvas doesn't allow us to stroke inside the width so we can

--- a/dashboard-app/src/components/StackedBarChart/RoundedBar/RoundedBarChart.ts
+++ b/dashboard-app/src/components/StackedBarChart/RoundedBar/RoundedBarChart.ts
@@ -1,0 +1,121 @@
+/*
+ * RoundedBarChart
+ *
+ * See: https://stackoverflow.com/questions/43254153/how-to-create-rounded-bars-for-bar-chart-js-v2
+ */
+import Chart, { PositionType } from 'chart.js';
+import { clamp } from 'ramda';
+import { Rectangles, Corners, Rectangle, Corner } from './Rectangles';
+
+
+type DrawingParams = {
+  ctx: CanvasRenderingContext2D
+  rectangle: Rectangle
+  corner: Corner
+  borderWidth: number
+  fillStyle: string
+  strokeStyle: string
+  radius?: number
+};
+
+const draw = ({ ctx, rectangle, corner, radius, ...params }: DrawingParams) => {
+  const { left, top, width, height } = rectangle;
+
+  ctx.beginPath();
+  ctx.fillStyle = params.fillStyle;
+  ctx.strokeStyle = params.strokeStyle;
+  ctx.lineWidth = params.borderWidth;
+
+  // Draw rectangle from first corner
+  ctx.moveTo(corner.x, corner.y);
+
+  if (radius && radius > 0) {
+    ctx.moveTo(left + radius, top);
+
+    ctx.lineTo(left + width - radius, top);
+
+    // top right
+    ctx.quadraticCurveTo(left + width, top, left + width, top + radius);
+    ctx.lineTo(left + width, top + height - radius);
+
+    // bottom right
+    ctx.lineTo(left + width, top + height);
+    ctx.lineTo(left + radius, top + height);
+
+    // bottom left
+    ctx.lineTo(left, top + height);
+    ctx.lineTo(left, top + radius);
+
+    // top left
+    ctx.quadraticCurveTo(left, top, left + radius, top);
+
+  } else {
+    ctx.moveTo(left, top);
+    ctx.lineTo(left + width, top);
+    ctx.lineTo(left + width, top + height);
+    ctx.lineTo(left, top + height);
+    ctx.lineTo(left, top);
+  }
+
+  ctx.fill();
+  if (params.borderWidth) {
+    ctx.stroke();
+  }
+};
+
+// If radius is less than 0 or is large enough to cause drawing errors a max radius is imposed.
+// 0 < R < Min(|H|/2, |W|/2)
+const calculateRadius = (height: number, width: number, radius: number = 0) =>
+  clamp(0, Math.min(height, width) / 2, radius);
+
+
+/*
+ * !!MUTATION!!
+ *
+ * When invoked this:
+ * 1. Mutates the `Chart.elements` object, adding a `RoundedTopRectangle` element type
+ * 2. Mutates the `Chart` object, adding a new chart type `roundedBar`
+ */
+export default () => {
+  (Chart as any).elements.RoundedTopRectangle = (Chart as any).elements.Rectangle.extend({
+    draw () {
+      const ctx = this._chart.ctx;
+      const vm = this._view;
+      const borderSkipped: PositionType = vm.borderSkipped || 'bottom';
+
+      const rectBase = Rectangles.init(
+        vm.x - vm.width / 2,
+        vm.x + vm.width / 2,
+        vm.y,
+        vm.base
+      );
+      const borderWidth = Rectangles.adjustBorderWidth(vm.borderWidth, rectBase);
+      const rect = Rectangles.adjustByBorder(borderSkipped, borderWidth, rectBase);
+      const corners = Corners.fromRectangle(rect);
+      const radius = calculateRadius(
+        rect.absHeight,
+        rect.absWidth,
+        this._chart.config.options.cornerRadius
+      );
+
+      const remainingDatasets = this._chart.data.datasets.slice(this._datasetIndex + 1);
+      const shouldNotRound = remainingDatasets
+        .some((dataset: any) => dataset.data[this._index] > 0 && !dataset._meta[0].hidden);
+
+      draw({
+        ctx,
+        rectangle: rect,
+        corner: corners[0],
+        radius: shouldNotRound ? 0 : radius,
+        fillStyle: vm.backgroundColor,
+        strokeStyle: vm.borderColor,
+        borderWidth,
+      });
+    },
+  });
+
+  Chart.defaults.roundedBar = Chart.helpers.clone(Chart.defaults.bar);
+  Chart.controllers.roundedBar = Chart.controllers.bar.extend({
+    dataElementType: (Chart as any).elements.RoundedTopRectangle,
+  });
+};

--- a/dashboard-app/src/components/StackedBarChart/RoundedBar/RoundedBarChart.ts
+++ b/dashboard-app/src/components/StackedBarChart/RoundedBar/RoundedBarChart.ts
@@ -68,6 +68,13 @@ const draw = ({ ctx, rectangle, corner, radius, ...params }: DrawingParams) => {
 const calculateRadius = (height: number, width: number, radius: number = 0) =>
   clamp(0, Math.min(height, width) / 2, radius);
 
+export const checkShouldRound = (datasets: any, datasetIdx: number, dataIdx: number) =>
+  !datasets
+    .slice(datasetIdx + 1)
+    .some((dataset: any) =>
+      dataset.data[dataIdx] > 0 &&
+      !(dataset._meta && dataset._meta[0] && dataset._meta[0].hidden)
+    );
 
 /*
  * !!MUTATION!!
@@ -98,15 +105,17 @@ export default () => {
         this._chart.config.options.cornerRadius
       );
 
-      const remainingDatasets = this._chart.data.datasets.slice(this._datasetIndex + 1);
-      const shouldNotRound = remainingDatasets
-        .some((dataset: any) => dataset.data[this._index] > 0 && !dataset._meta[0].hidden);
+      const shouldRound = checkShouldRound(
+        this._chart.data.datasets,
+        this._datasetIndex,
+        this._index
+      );
 
       draw({
         ctx,
         rectangle: rect,
         corner: corners[0],
-        radius: shouldNotRound ? 0 : radius,
+        radius: shouldRound ? radius : 0,
         fillStyle: vm.backgroundColor,
         strokeStyle: vm.borderColor,
         borderWidth,

--- a/dashboard-app/src/components/StackedBarChart/RoundedBar/RoundedBarChart.ts
+++ b/dashboard-app/src/components/StackedBarChart/RoundedBar/RoundedBarChart.ts
@@ -18,7 +18,7 @@ type DrawingParams = {
   radius?: number
 };
 
-const draw = ({ ctx, rectangle, corner, radius, ...params }: DrawingParams) => {
+export const draw = ({ ctx, rectangle, corner, radius, ...params }: DrawingParams) => {
   const { left, top, width, height } = rectangle;
 
   ctx.beginPath();
@@ -30,23 +30,23 @@ const draw = ({ ctx, rectangle, corner, radius, ...params }: DrawingParams) => {
   ctx.moveTo(corner.x, corner.y);
 
   if (radius && radius > 0) {
+    // top line
     ctx.moveTo(left + radius, top);
-
     ctx.lineTo(left + width - radius, top);
 
-    // top right
+    // top right corner
     ctx.quadraticCurveTo(left + width, top, left + width, top + radius);
-    ctx.lineTo(left + width, top + height - radius);
 
-    // bottom right
+    // right line
     ctx.lineTo(left + width, top + height);
-    ctx.lineTo(left + radius, top + height);
 
-    // bottom left
+    // bottom line
     ctx.lineTo(left, top + height);
+
+    // left line
     ctx.lineTo(left, top + radius);
 
-    // top left
+    // top left corner
     ctx.quadraticCurveTo(left, top, left + radius, top);
 
   } else {
@@ -65,10 +65,21 @@ const draw = ({ ctx, rectangle, corner, radius, ...params }: DrawingParams) => {
 
 // If radius is less than 0 or is large enough to cause drawing errors a max radius is imposed.
 // 0 < R < Min(|H|/2, |W|/2)
-const calculateRadius = (height: number, width: number, radius: number = 0) =>
+export const calculateRadius = (height: number, width: number, radius: number = 0) =>
   clamp(0, Math.min(height, width) / 2, radius);
 
-export const checkShouldRound = (datasets: any, datasetIdx: number, dataIdx: number) =>
+/**
+ * Determines whether the current dataset (represented by `datasetIdx`) of the current
+ * x-axis index (represented by `dataIdx`) should render as a rounded rectangle or not.
+ * Only the top-most rectangle in the stack should be rendered.
+ *
+ * Chart.js iterates through the datasets when rendering, using `datasetIdx`.
+ * This function uses `datasetIdx` to grab the datasets that _remain to be rendered_ after
+ * the current dataset. If any of those datasets either (1) are hidden, or (2) have non-zero
+ * data at the current value of `dataIdx`, then the rectangle for the current `datasetIdx`
+ * should _not_ be rounded, since it will not be the top-most one in the stack.
+ */
+export const checkShouldRound = (datasets: any[], datasetIdx: number, dataIdx: number) =>
   !datasets
     .slice(datasetIdx + 1)
     .some((dataset: any) =>

--- a/dashboard-app/src/components/StackedBarChart/RoundedBar/__tests__/Rectangles.test.ts
+++ b/dashboard-app/src/components/StackedBarChart/RoundedBar/__tests__/Rectangles.test.ts
@@ -1,0 +1,105 @@
+import { Rectangles, Corners } from '../Rectangles';
+
+describe('Rectangles', () => {
+  describe('adjustBorderWidth', () => {
+    [
+      {
+        name: 'bw < 0 < width < height',
+        bw: -1,
+        w: 10,
+        h: 20,
+        expected: 0,
+      },
+      {
+        name: '0 < bw < width < height',
+        bw: 1,
+        w: 10,
+        h: 20,
+        expected: 1,
+      },
+      {
+        name: '0 < width < bw < height',
+        bw: 10,
+        w: 1,
+        h: 20,
+        expected: 1,
+      },
+      {
+        name: '0 < width < height < bw',
+        bw: 20,
+        w: 1,
+        h: 10,
+        expected: 1,
+      },
+      {
+        name: 'bw < 0 < height < width',
+        bw: -1,
+        w: 20,
+        h: 10,
+        expected: 0,
+      },
+      {
+        name: '0 < bw < height < width',
+        bw: 1,
+        w: 20,
+        h: 10,
+        expected: 1,
+      },
+      {
+        name: '0 < height < bw < width',
+        bw: 10,
+        w: 20,
+        h: 1,
+        expected: 1,
+      },
+      {
+        name: '0 < height < width < bw',
+        bw: 20,
+        w: 10,
+        h: 1,
+        expected: 1,
+      },
+    ]
+      .forEach(({ bw, w, h, name, expected }) => {
+        test(name, () => {
+          expect(Rectangles.adjustBorderWidth(bw, Rectangles.init(0, w, 0, -h))).toBe(expected);
+        });
+      });
+  });
+});
+
+describe('Corners', () => {
+  describe('fromRectangle', () => {
+    test('initialises correctly from Rectangle', () => {
+      expect(Corners.fromRectangle(Rectangles.init(0, 10, 0, -10)))
+        .toEqual([
+          { x: 0, y: -10 },
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+          { x: 10, y: -10 },
+        ]);
+    });
+  });
+
+  describe('selectByPosition', () => {
+    const r = Rectangles.init(0, 10, 0, -10);
+
+    test('left', () => {
+      const cs = Corners.fromRectangle(r);
+      expect(Corners.selectByPosition('left', cs)).toEqual({ x: 0, y: 0 });
+    });
+    test('right', () => {
+      const cs = Corners.fromRectangle(r);
+      expect(Corners.selectByPosition('right', cs)).toEqual({ x: 10, y: -10 });
+    });
+    test('top', () => {
+      const cs = Corners.fromRectangle(r);
+      expect(Corners.selectByPosition('top', cs)).toEqual({ x: 10, y: 0 });
+    });
+    test('bottom', () => {
+      const cs = Corners.fromRectangle(r);
+      expect(Corners.selectByPosition('bottom', cs)).toEqual({ x: 0, y: -10 });
+    });
+    test('other', () => {});
+  });
+});

--- a/dashboard-app/src/components/StackedBarChart/RoundedBar/__tests__/RoundedBarChart.test.ts
+++ b/dashboard-app/src/components/StackedBarChart/RoundedBar/__tests__/RoundedBarChart.test.ts
@@ -1,0 +1,196 @@
+import { draw, calculateRadius, checkShouldRound } from '../RoundedBarChart';
+import { Rectangles, Corners } from '../Rectangles';
+
+describe('RoundedBarChart', () => {
+  describe('draw', () => {
+    const MockCtx = jest.fn(() => ({
+      beginPath: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      quadraticCurveTo: jest.fn(),
+      fill: jest.fn(),
+      stroke: jest.fn(),
+    }));
+
+    test('rounded rectangle, no border width', () => {
+      const ctx = new MockCtx();
+      const rectangle = Rectangles.init(0, 10, 0, -10);
+      const corners = Corners.fromRectangle(rectangle);
+      const radius = 2;
+
+      draw({
+        ctx: ctx as any,
+        rectangle,
+        corner: corners[0],
+        radius,
+        borderWidth: 0,
+        fillStyle: '',
+        strokeStyle: '',
+      });
+
+      expect(ctx.beginPath).toHaveBeenCalledTimes(1);
+      expect(ctx.fill).toHaveBeenCalledTimes(1);
+      expect(ctx.stroke).not.toHaveBeenCalled();
+      expect(ctx.moveTo).toHaveBeenCalledTimes(2);
+      expect(ctx.moveTo).toHaveBeenNthCalledWith(1, 0, -10);
+      expect(ctx.moveTo).toHaveBeenNthCalledWith(2, 2, 0);
+      expect(ctx.lineTo).toHaveBeenNthCalledWith(1, 8, 0);
+      expect(ctx.lineTo).toHaveBeenNthCalledWith(2, 10, -10);
+      expect(ctx.lineTo).toHaveBeenNthCalledWith(3, 0, -10);
+      expect(ctx.lineTo).toHaveBeenNthCalledWith(4, 0, 2);
+      expect(ctx.quadraticCurveTo).toHaveBeenNthCalledWith(1, 10, 0, 10, 2);
+      expect(ctx.quadraticCurveTo).toHaveBeenNthCalledWith(2, 0, 0, 2, 0);
+    });
+
+    test('normal rectangle, no border width', () => {
+      const ctx = new MockCtx();
+      const rectangle = Rectangles.init(0, 10, 0, -10);
+      const corners = Corners.fromRectangle(rectangle);
+      const radius = 0;
+
+      draw({
+        ctx: ctx as any,
+        rectangle,
+        corner: corners[0],
+        radius,
+        borderWidth: 0,
+        fillStyle: '',
+        strokeStyle: '',
+      });
+
+      expect(ctx.beginPath).toHaveBeenCalledTimes(1);
+      expect(ctx.fill).toHaveBeenCalledTimes(1);
+      expect(ctx.stroke).not.toHaveBeenCalled();
+      expect(ctx.moveTo).toHaveBeenCalledTimes(2);
+      expect(ctx.moveTo).toHaveBeenNthCalledWith(1, 0, -10);
+      expect(ctx.moveTo).toHaveBeenNthCalledWith(2, 0, 0);
+      expect(ctx.lineTo).toHaveBeenNthCalledWith(1, 10, 0);
+      expect(ctx.lineTo).toHaveBeenNthCalledWith(2, 10, -10);
+      expect(ctx.lineTo).toHaveBeenNthCalledWith(3, 0, -10);
+      expect(ctx.lineTo).toHaveBeenNthCalledWith(4, 0, 0);
+    });
+
+    test('normal rectangle, border width', () => {
+      const ctx = new MockCtx();
+      const rectangle = Rectangles.init(0, 10, 0, -10);
+      const corners = Corners.fromRectangle(rectangle);
+      const radius = 0;
+
+      draw({
+        ctx: ctx as any,
+        rectangle,
+        corner: corners[0],
+        radius,
+        borderWidth: 1,
+        fillStyle: '',
+        strokeStyle: '',
+      });
+
+      expect(ctx.beginPath).toHaveBeenCalledTimes(1);
+      expect(ctx.fill).toHaveBeenCalledTimes(1);
+      expect(ctx.stroke).toHaveBeenCalledTimes(1);
+      expect(ctx.moveTo).toHaveBeenCalledTimes(2);
+      expect(ctx.moveTo).toHaveBeenNthCalledWith(1, 0, -10);
+      expect(ctx.moveTo).toHaveBeenNthCalledWith(2, 0, 0);
+      expect(ctx.lineTo).toHaveBeenNthCalledWith(1, 10, 0);
+      expect(ctx.lineTo).toHaveBeenNthCalledWith(2, 10, -10);
+      expect(ctx.lineTo).toHaveBeenNthCalledWith(3, 0, -10);
+      expect(ctx.lineTo).toHaveBeenNthCalledWith(4, 0, 0);
+    });
+  });
+
+  describe('calculateRadius', () => {
+    test('no radius', () => {
+      expect(calculateRadius(10, 5)).toBe(0);
+    });
+    test('2 * radius < 0 < W < H', () => {
+      expect(calculateRadius(10, 5, -2)).toBe(0);
+    });
+    test('0 < 2 * radius < W < H', () => {
+      expect(calculateRadius(10, 5, 2)).toBe(2);
+    });
+    test('0 < W < 2 * radius < H', () => {
+      expect(calculateRadius(10, 5, 3)).toBe(2.5);
+    });
+    test('0 < W < H < 2 * radius', () => {
+      expect(calculateRadius(10, 5, 6)).toBe(2.5);
+    });
+    test('2 * radius < 0 < H < W', () => {
+      expect(calculateRadius(5, 10, -2)).toBe(0);
+    });
+    test('0 < 2 * radius < H < W', () => {
+      expect(calculateRadius(5, 10, 2)).toBe(2);
+    });
+    test('0 < H < 2 * radius < W', () => {
+      expect(calculateRadius(5, 10, 3)).toBe(2.5);
+    });
+    test('0 < H < W < 2 * radius', () => {
+      expect(calculateRadius(5, 10, 6)).toBe(2.5);
+    });
+  });
+
+  describe('checkShouldRound', () => {
+    test('final dataset = should round', () => {
+      const datasets = [{}];
+      expect(checkShouldRound(datasets, 1, 0)).toBe(true);
+    });
+
+    test('zero remaining hidden datasets have data = should round', () => {
+      const data = [0, 0, 0, 0, 0, 0];
+      const datasets = [{}, { data, _meta: [{ hidden: true }] }];
+      data.forEach((_, idx) => {
+        expect(checkShouldRound(datasets, 0, idx)).toBe(true);
+      });
+    });
+
+    test('one remaining hidden dataset has data = should round', () => {
+      const data = [0, 0, 0, 1, 0, 0];
+      const datasets = [{}, { data, _meta: [{ hidden: true }] }];
+      data.forEach((_, idx) => {
+        expect(checkShouldRound(datasets, 0, idx)).toBe(true);
+      });
+    });
+
+    test('multiple remaining hidden datasets have data = should round', () => {
+      const datasets = [
+        {},
+        { data: [0, 0, 0, 1], _meta: [{ hidden: true }] },
+        { data: [0, 0, 2, 1], _meta: [{ hidden: true }] },
+        { data: [0, 1, 0, 1], _meta: [{ hidden: true }] },
+      ];
+      expect(checkShouldRound(datasets, 0, 0)).toBe(true);
+      expect(checkShouldRound(datasets, 0, 1)).toBe(true);
+      expect(checkShouldRound(datasets, 0, 2)).toBe(true);
+      expect(checkShouldRound(datasets, 0, 3)).toBe(true);
+    });
+
+    test('zero remaining un-hidden datasets have data = should round', () => {
+      const datasets = [
+        {},
+        { data: [0, 0, 0, 0, 0, 0] },
+      ];
+      expect(checkShouldRound(datasets, 0, 2)).toBe(true);
+    });
+
+    test('one remaining un-hidden dataset has data = varying', () => {
+      const data = [0, 0, 0, 1, 0, 0];
+      const datasets = [{}, { data }];
+      data.forEach((value, idx) => {
+        expect(checkShouldRound(datasets, 0, idx)).toBe(value === 0);
+      });
+    });
+
+    test('multiple remaining un-hidden datasets have data = varying', () => {
+      const datasets = [
+        {},
+        { data: [0, 0, 0, 1] },
+        { data: [0, 0, 2, 1] },
+        { data: [0, 1, 0, 1] },
+      ];
+      expect(checkShouldRound(datasets, 0, 0)).toBe(true);
+      expect(checkShouldRound(datasets, 0, 1)).toBe(false);
+      expect(checkShouldRound(datasets, 0, 2)).toBe(false);
+      expect(checkShouldRound(datasets, 0, 3)).toBe(false);
+    });
+  });
+});

--- a/dashboard-app/src/components/StackedBarChart/RoundedBar/index.tsx
+++ b/dashboard-app/src/components/StackedBarChart/RoundedBar/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { ChartType } from 'chart.js';
+import ChartComponent, { ChartComponentProps } from 'react-chartjs-2';
+import augmentChartJs from './RoundedBarChart';
+
+
+// MUTATES `Chart`
+augmentChartJs();
+
+
+class RoundedBar extends React.Component<ChartComponentProps> {
+  render () {
+    return (
+      <ChartComponent
+        {...this.props}
+        type={'roundedBar' as ChartType}
+      />
+    );
+  }
+}
+
+export default RoundedBar;

--- a/dashboard-app/src/components/StackedBarChart/index.tsx
+++ b/dashboard-app/src/components/StackedBarChart/index.tsx
@@ -17,6 +17,8 @@ import {
 import Legend from './Legend/index';
 import Chart from './Chart';
 import { LegendData } from './types';
+import _DataTable from '../DataTable';
+import _Card from '../Card';
 
 
 /*
@@ -71,7 +73,8 @@ const StackedBarChart: FunctionComponent<Props> = (props) => {
   }, [legendData]);
 
   const chartProps = { data: chartData, xAxisTitle, yAxisTitle, title, unit };
-  const legendProps = { legendData, setLegendActivityOfAll, setLegendActivityOnUpdate, title: data.groupByX }; // tslint:disable-line:max-line-length
+// tslint:disable-next-line: max-line-length
+  const legendProps = { legendData, setLegendActivityOfAll, setLegendActivityOnUpdate, title: data.groupByX };
 
   return (
     <Grid>

--- a/dashboard-app/src/components/StackedBarChart/index.tsx
+++ b/dashboard-app/src/components/StackedBarChart/index.tsx
@@ -13,12 +13,9 @@ import {
   AggregatedData,
   IdAndName,
 } from '../../dashboard/dataManipulation/logsToAggregatedData';
-
 import Legend from './Legend/index';
 import Chart from './Chart';
 import { LegendData } from './types';
-import _DataTable from '../DataTable';
-import _Card from '../Card';
 
 
 /*

--- a/dashboard-app/src/components/StackedBarChart/utils/chartjsUtils.ts
+++ b/dashboard-app/src/components/StackedBarChart/utils/chartjsUtils.ts
@@ -1,6 +1,7 @@
 import { MathUtil } from 'twine-util';
 const round = MathUtil.roundTo(2);
 
+
 export const totalizer = {
   id: 'totalizer',
 
@@ -35,7 +36,7 @@ export const getStackedGraphOptions = (xAxisTitle: string, yAxisTitle: string): 
         labelString: xAxisTitle,
       },
       stacked: true,
-      gridLines: false,
+      gridLines: { display: false },
       ticks: { padding: 5 },
     }],
     yAxes: [{
@@ -44,7 +45,7 @@ export const getStackedGraphOptions = (xAxisTitle: string, yAxisTitle: string): 
         labelString: yAxisTitle,
       },
       stacked: true,
-      gridLines: false,
+      gridLines: { display: false },
       ticks: { display: false },
     }],
   },
@@ -59,11 +60,12 @@ export const getStackedGraphOptions = (xAxisTitle: string, yAxisTitle: string): 
         const total = ctx.chart.$totalizer.totals[ctx.dataIndex];
         return total.toString();
       },
-      align: 'end',
-      anchor: 'end',
+      align: 'end' as 'end',
+      anchor: 'end' as 'end',
       display (ctx: any) {
         return ctx.datasetIndex === ctx.chart.$totalizer.utmost;
       },
     },
   },
+  cornerRadius: 5,
 });

--- a/dashboard-app/src/dashboard/ByTime/__tests__/index.test.ts
+++ b/dashboard-app/src/dashboard/ByTime/__tests__/index.test.ts
@@ -7,7 +7,7 @@ import ByTime from '..';
 import 'jest-dom/extend-expect';
 
 
-jest.mock('react-chartjs-2', () => ({ Bar: () => null }));
+jest.mock('react-chartjs-2', () => ({ __esModule: true, default: () => null }));
 
 
 describe('By Time Page', () => {

--- a/dashboard-app/src/dashboard/ByVolunteer/__tests__/index.test.ts
+++ b/dashboard-app/src/dashboard/ByVolunteer/__tests__/index.test.ts
@@ -7,7 +7,7 @@ import ByVolunteer from '..';
 import 'jest-dom/extend-expect';
 
 
-jest.mock('react-chartjs-2', () => ({ Bar: () => null }));
+jest.mock('react-chartjs-2', () => ({ __esModule: true, default: () => null }));
 
 
 describe('By Volunteer Page', () => {

--- a/dashboard-app/src/dashboard/dataManipulation/aggregatedToGraphData.ts
+++ b/dashboard-app/src/dashboard/dataManipulation/aggregatedToGraphData.ts
@@ -1,6 +1,7 @@
+import { Objects } from 'twine-util';
 import { AggregatedData } from './logsToAggregatedData';
 import { toUnitDuration, abbreviateIfDateString } from './util';
-import { omit, map, Dictionary } from 'ramda';
+import { omit } from 'ramda';
 import { DurationUnitEnum } from '../../types';
 import { GraphColourList } from '../../styles/design_system';
 import Months from '../../util/months';
@@ -12,11 +13,11 @@ export const aggregatedToStackedGraph = (data: AggregatedData, unit: DurationUni
     datasets: data.rows.map((row, i) => {
       const label = row.name as string;
       const rowData = omit(['id', 'name'], row);
-      const numericData = map((v) =>
+      const numericData = Objects.mapValues((v) =>
         typeof v === 'object'
           ? toUnitDuration(unit, v)
-          : v
-        , rowData) as Dictionary<any>;
+          : Number(v)
+        , rowData);
       return {
         backgroundColor: GraphColourList[i],
         label,


### PR DESCRIPTION
Related to #130 

Found that the code actually admitted quite a bit of re-organisation, and that a _lot_ more of it was dead code than we thought!

### Changes
* Create types for basic concepts required for drawing calculations
* Separate side-effects (drawing) from pure stuff (calculating parameters for drawing)
* Make rounding work with native legend (by inspecting hidden) as well as with custom legend (by relying on 0-values)
* `RoundedBarChart` exports a mutating function so its parent can control when the mutation occurs.