### PR TITLE
🐛 fix legend data creation

### DIFF
--- a/dashboard-app/src/components/StackedBarChart/index.tsx
+++ b/dashboard-app/src/components/StackedBarChart/index.tsx
@@ -24,7 +24,6 @@ import { LegendData } from './types';
 
 interface Props {
   data: AggregatedData;
-  legendOptions: IdAndName[];
   unit: DurationUnitEnum;
   xAxisTitle: string;
   yAxisTitle: string;
@@ -36,8 +35,8 @@ interface Props {
  */
 
 const StackedBarChart: FunctionComponent<Props> = (props) => {
-  const { data, xAxisTitle, yAxisTitle, title, unit, legendOptions } = props;
-  const [legendData, setLegendData] = useState(createLegendData(data, legendOptions));
+  const { data, xAxisTitle, yAxisTitle, title, unit } = props;
+  const [legendData, setLegendData] = useState(createLegendData(data));
   const [chartData, setChartData] = useState();
 
   const setLegendActivityOnUpdate = (id: number) => {
@@ -58,7 +57,7 @@ const StackedBarChart: FunctionComponent<Props> = (props) => {
 
 
   useEffect(() => {
-    const newLegendData = updateLegendData(data, legendOptions, legendData);
+    const newLegendData = updateLegendData(data, legendData);
     const zeroedOutData = sortAndZeroOutInactiveData(data, newLegendData);
     setLegendData(newLegendData);
     setChartData(aggregatedToStackedGraph(zeroedOutData, unit));

--- a/dashboard-app/src/components/StackedBarChart/index.tsx
+++ b/dashboard-app/src/components/StackedBarChart/index.tsx
@@ -9,10 +9,7 @@ import {
 } from './utils/util';
 import { DurationUnitEnum } from '../../types';
 import { aggregatedToStackedGraph } from '../../dashboard/dataManipulation/aggregatedToGraphData';
-import {
-  AggregatedData,
-  IdAndName,
-} from '../../dashboard/dataManipulation/logsToAggregatedData';
+import { AggregatedData } from '../../dashboard/dataManipulation/logsToAggregatedData';
 import Legend from './Legend/index';
 import Chart from './Chart';
 import { LegendData } from './types';

--- a/dashboard-app/src/components/StackedBarChart/utils/__tests__/index.test.ts
+++ b/dashboard-app/src/components/StackedBarChart/utils/__tests__/index.test.ts
@@ -110,17 +110,7 @@ describe('Helpers', () => {
             { 'Outdoor and practical work': { minutes: 2 }, name: 'Aku Aku', id: 2 },
             { 'Outdoor and practical work': { hours: 4, minutes: 23 }, name: 'Crash Bandicoot', id: 3 },
         ]} as AggregatedData;
-      const vols = [
-        {
-          name: 'Aku Aku',
-          id: 2,
-        },
-        {
-          name: 'Crash Bandicoot',
-          id: 3,
-        },
-      ];
-      const expected = createLegendData(aggregatedData, vols);
+      const expected = createLegendData(aggregatedData);
       expect(expected).toEqual([
         { active: true, name: 'Aku Aku', id: 2 },
         { active: true, name: 'Crash Bandicoot', id: 3 },
@@ -134,21 +124,8 @@ describe('Helpers', () => {
             { 'Outdoor and practical work': { minutes: 2 }, name: 'Aku Aku', id: 2 },
             { 'Outdoor and practical work': { hours: 4, minutes: 23 }, name: 'Crash Bandicoot', id: 3 },
         ]} as AggregatedData;
-      const vols = [
-        {
-          name: 'Aku Aku',
-          id: 2,
-        },
-        {
-          name: 'Crash Bandicoot',
-          id: 3,
-        },
-        {
-          name: 'Dr Neo Cortex',
-          id: 7,
-        },
-      ];
-      const expected = createLegendData(aggregatedData, vols);
+
+      const expected = createLegendData(aggregatedData);
       expect(expected).toEqual([
         { active: true, name: 'Aku Aku', id: 2 },
         { active: true, name: 'Crash Bandicoot', id: 3 },
@@ -165,16 +142,7 @@ describe('Helpers', () => {
             { 'Outdoor and practical work': { minutes: 2 }, name: 'Aku Aku', id: 2 },
             { 'Outdoor and practical work': { hours: 4, minutes: 23 }, name: 'Crash Bandicoot', id: 3 },
         ]} as AggregatedData;
-      const vols = [
-        {
-          name: 'Aku Aku',
-          id: 2,
-        },
-        {
-          name: 'Crash Bandicoot',
-          id: 3,
-        },
-      ];
+
       const oldActiveData = [
         {
           active: true,
@@ -187,7 +155,7 @@ describe('Helpers', () => {
           id: 3,
         },
       ];
-      const expected = updateLegendData(aggregatedData, vols, oldActiveData);
+      const expected = updateLegendData(aggregatedData, oldActiveData);
       expect(expected).toEqual([
         { active: true, name: 'Aku Aku', id: 2 },
         { active: false, name: 'Crash Bandicoot', id: 3 },
@@ -234,6 +202,31 @@ describe('Helpers', () => {
     });
   });
 
+  describe(':: sortAndZeroOutInactiveData', async () => {
+    test('Success :: replaces all inactive data with 0', async () => {
+      const aggregatedData = {
+        groupByX: 'Volunteer Name',
+        groupByY: '',
+        rows: [
+            { 'Outdoor and practical work': { minutes: 2 }, name: 'Aku Aku', id: 3 },
+            { 'Outdoor and practical work': { hours: 4, minutes: 23 }, name: 'Crash Bandicoot', id: 4 },
+        ]} as AggregatedData;
+
+      const activeData = [
+        { active: false, name: 'Aku Aku', id: 3 },
+        { active: true, name: 'Crash Bandicoot', id: 4 },
+      ];
+      const expected = sortAndZeroOutInactiveData(aggregatedData, activeData);
+      expect(expected).toEqual({
+        groupByX: 'Volunteer Name',
+        groupByY: '',
+        rows: [
+          { 'Outdoor and practical work': 0, name: 'Aku Aku', id: 3 },
+          { 'Outdoor and practical work': { hours: 4, minutes: 23 }, name: 'Crash Bandicoot', id: 4 },
+        ] }
+      );
+    });
+  });
   describe(':: sortAndZeroOutInactiveData', async () => {
     test('Success :: replaces all inactive data with 0', async () => {
       const aggregatedData = {

--- a/dashboard-app/src/components/StackedBarChart/utils/util.ts
+++ b/dashboard-app/src/components/StackedBarChart/utils/util.ts
@@ -1,11 +1,7 @@
 
 
 import { sortBy, pipe, prop, toLower, omit, evolve } from 'ramda';
-import {
-  AggregatedData,
-  IdAndName,
-  Row
-} from '../../../dashboard/dataManipulation/logsToAggregatedData';
+import { AggregatedData, Row } from '../../../dashboard/dataManipulation/logsToAggregatedData';
 import { LegendData, LegendDatum } from '../types';
 
 export const sortByNameCaseInsensitive = sortBy(pipe(prop('name'), toLower));

--- a/dashboard-app/src/components/StackedBarChart/utils/util.ts
+++ b/dashboard-app/src/components/StackedBarChart/utils/util.ts
@@ -45,6 +45,7 @@ export const getYHeaderList = (row: Row) => Object.keys(omit(['id', 'name'], row
 const zeroOutInactiveData = (legendData: LegendData) => (rows: Row[]) =>
   rows.
     map((row, i: number) => {
+      if (! legendData[i]) return row;
       return legendData[i].active
     ? row
     : getYHeaderList(row).reduce((acc: object, el) => ({ ...acc, [el]: 0 }),

--- a/dashboard-app/src/dashboard/ByTime/TimeTabs.tsx
+++ b/dashboard-app/src/dashboard/ByTime/TimeTabs.tsx
@@ -4,7 +4,7 @@ import { Row, Col } from 'react-flexbox-grid';
 
 import _DataTable from '../../components/DataTable';
 import { TabGroup } from '../../components/Tabs';
-import { AggregatedData, IdAndName } from '../dataManipulation/logsToAggregatedData';
+import { AggregatedData } from '../dataManipulation/logsToAggregatedData';
 import { DurationUnitEnum } from '../../types';
 import { TableData } from '../dataManipulation/aggregatedToTableData';
 import StackedBarChart from '../../components/StackedBarChart/index';
@@ -15,7 +15,6 @@ import StackedBarChart from '../../components/StackedBarChart/index';
 
 interface Props {
   data?: AggregatedData;
-  legendOptions: IdAndName[];
   unit: DurationUnitEnum;
   tableData: TableData;
   sortBy: number;
@@ -33,7 +32,7 @@ const DataTable = styled(_DataTable)`
  * Component
  */
 const TimeTabs: FunctionComponent<Props> = (props) => {
-  const { data, unit, tableData, sortBy, onChangeSortBy, title, legendOptions } = props;
+  const { data, unit, tableData, sortBy, onChangeSortBy, title } = props;
 
   return(
     <Row center="xs">
@@ -42,7 +41,6 @@ const TimeTabs: FunctionComponent<Props> = (props) => {
           {
             data && (
               <StackedBarChart
-                legendOptions={legendOptions}
                 title={title}
                 data={data}
                 unit={unit}

--- a/dashboard-app/src/dashboard/ByTime/index.tsx
+++ b/dashboard-app/src/dashboard/ByTime/index.tsx
@@ -18,7 +18,6 @@ import Errors from '../../components/Errors';
 import useAggregateDataByTime from '../hooks/useAggregateDataByTime';
 import Months from '../../util/months';
 import { Dictionary } from 'ramda';
-import { IdAndName } from '../dataManipulation/logsToAggregatedData';
 
 
 /**
@@ -46,7 +45,7 @@ const ByTime: FunctionComponent<RouteComponentProps> = (props) => {
   const [toDate, setToDate] = useState<Date>(DatePickerConstraints.to.default());
   const [errors, setErrors] = useState<Dictionary<string>>({});
   const [tableData, setTableData] = useState<TableData>(initTableData);
-  const { data, loading, error, activities, months } =
+  const { data, loading, error, months } =
     useAggregateDataByTime({ from: fromDate, to: toDate });
 
   useEffect(() => {
@@ -83,7 +82,6 @@ const ByTime: FunctionComponent<RouteComponentProps> = (props) => {
     tableData,
     sortBy,
     onChangeSortBy,
-    legendOptions: activities as IdAndName[],
     title: getTitle(fromDate, toDate),
   };
 

--- a/dashboard-app/src/dashboard/ByVolunteer/VolunteerTabs.tsx
+++ b/dashboard-app/src/dashboard/ByVolunteer/VolunteerTabs.tsx
@@ -4,7 +4,7 @@ import { Row, Col } from 'react-flexbox-grid';
 
 import _DataTable from '../../components/DataTable';
 import { TabGroup } from '../../components/Tabs';
-import { AggregatedData, IdAndName } from '../dataManipulation/logsToAggregatedData';
+import { AggregatedData } from '../dataManipulation/logsToAggregatedData';
 import { DurationUnitEnum } from '../../types';
 import { TableData } from '../dataManipulation/aggregatedToTableData';
 import StackedBarChart from '../../components/StackedBarChart/index';
@@ -20,7 +20,6 @@ interface Props {
   sortBy: number;
   onChangeSortBy: (x: string) => void;
   title: string;
-  legendOptions?: IdAndName[];
 }
 
 /*
@@ -34,19 +33,18 @@ const DataTable = styled(_DataTable)`
  * Component
  */
 const VolunteerTabs: FunctionComponent<Props> = (props) => {
-  const { data, unit, tableData, sortBy, onChangeSortBy, title, legendOptions } = props;
+  const { data, unit, tableData, sortBy, onChangeSortBy, title } = props;
 
   return(
     <Row center="xs">
       <Col xs={12}>
         <TabGroup titles={['Chart', 'Table']}>
           {
-            data && legendOptions && (
+            data && (
               <StackedBarChart
                 title={title}
                 data={data}
                 unit={unit}
-                legendOptions={legendOptions}
                 xAxisTitle={'Months'}
                 yAxisTitle={`Volunteer ${unit}`}
               />

--- a/dashboard-app/src/dashboard/ByVolunteer/index.tsx
+++ b/dashboard-app/src/dashboard/ByVolunteer/index.tsx
@@ -45,7 +45,7 @@ const ByVolunteer: FunctionComponent<RouteComponentProps> = (props) => {
   const [toDate, setToDate] = useState<Date>(DatePickerConstraints.to.default());
   const [tableData, setTableData] = useState<TableData>(initTableData);
   const [errors, setErrors] = useState<Dictionary<string>>({});
-  const { loading, data, error, months, volunteers } =
+  const { loading, data, error, months } =
     useAggregateDataByVolunteer({ from: fromDate, to: toDate });
 
   useEffect(() => {
@@ -82,7 +82,6 @@ const ByVolunteer: FunctionComponent<RouteComponentProps> = (props) => {
     tableData,
     sortBy,
     onChangeSortBy,
-    legendOptions: volunteers,
     title: getTitle(fromDate, toDate),
   };
 

--- a/dashboard-app/src/dashboard/hooks/useAggregateDataByTime.ts
+++ b/dashboard-app/src/dashboard/hooks/useAggregateDataByTime.ts
@@ -18,7 +18,6 @@ interface UseAggregatedDataParams {
 
 export default ({ from, to, updateOn = [] }: UseAggregatedDataParams) => {
   const [aggregatedData, setAggregatedData] = useState<AggregatedData>();
-  const [activities, setActivies] = useState<IdAndName[]>();
   const months = [...Months.range(from, to, Months.format.verbose)]
       .map((month, i) => ({
         id: i,
@@ -60,7 +59,6 @@ export default ({ from, to, updateOn = [] }: UseAggregatedDataParams) => {
       yData: months,
     });
 
-    setActivies(activitiesData.data);
     setAggregatedData(data);
   }, [logsData]);
 
@@ -75,7 +73,7 @@ export default ({ from, to, updateOn = [] }: UseAggregatedDataParams) => {
 
   } else {
 
-    return { loading, data: aggregatedData, error, activities, months };
+    return { loading, data: aggregatedData, error, months };
 
   }
 };

--- a/dashboard-app/src/dashboard/hooks/useAggregateDataByVolunteer.ts
+++ b/dashboard-app/src/dashboard/hooks/useAggregateDataByVolunteer.ts
@@ -18,7 +18,6 @@ interface UseAggregatedDataParams {
 
 export default ({ from, to, updateOn = [] }: UseAggregatedDataParams) => {
   const [aggregatedData, setAggregatedData] = useState<AggregatedData>();
-  const [volunteers, setVolunteers] = useState<IdAndName[]>();
   const months = [...Months.range(from, to, Months.format.verbose)]
   .map((month, i) => ({
     id: i,
@@ -60,7 +59,6 @@ export default ({ from, to, updateOn = [] }: UseAggregatedDataParams) => {
       yData: months,
     });
 
-    setVolunteers(volunteersData.data);
     setAggregatedData(data);
   }, [logsData, volunteersData]);
 
@@ -75,7 +73,7 @@ export default ({ from, to, updateOn = [] }: UseAggregatedDataParams) => {
 
   } else {
 
-    return { loading, data: aggregatedData, error, months, volunteers };
+    return { loading, data: aggregatedData, error, months };
 
   }
 };


### PR DESCRIPTION
**Changes:**
- legend data can be created from rows as it contains `id` & `name` values. Creating this data from requests (of activities or volunteers) causes discrepancies as soft deleted data is not present. 

fixes #157 