### PR TITLE
🐛 Error msg persistence

### DIFF
--- a/dashboard-app/src/dashboard/ByActivity/index.tsx
+++ b/dashboard-app/src/dashboard/ByActivity/index.tsx
@@ -55,15 +55,15 @@ const ByActivity: FunctionComponent<RouteComponentProps> = (props) => {
   const [toDate, setToDate] = useState<Date>(DatePickerConstraints.to.default());
   const [tableData, setTableData] = useState<TableData>(initTableData);
   const [errors, setErrors] = useState<Dictionary<string>>({});
-  const { loading, error: dataError, data, activities } =
+  const { loading, error, data, activities } =
     useAggregateDataByActivity({ from: fromDate, to: toDate });
 
   useEffect(() => {
-    if (dataError) {
-      setErrors({ data: dataError.message });
+    if (error) {
+      setErrors({ data: error.message });
     }
     setErrors(omit(['Download']));
-  }, [dataError, fromDate, toDate]);
+  }, [error, fromDate, toDate]);
 
   // manipulate data for table
   useEffect(() => {
@@ -84,7 +84,7 @@ const ByActivity: FunctionComponent<RouteComponentProps> = (props) => {
       setErrors(assoc('Download', 'There is no data available to download'));
     } else {
       downloadCsv({ data, fromDate, toDate, fileName: 'by_activity', unit })
-        .catch((error: Error) => setErrors(assoc('Download', error.message)));
+        .catch((err: Error) => setErrors(assoc('Download', err.message)));
     }
   }, [data, fromDate, toDate, unit]);
 

--- a/dashboard-app/src/dashboard/dataManipulation/__tests__/downloadCsv.test.ts
+++ b/dashboard-app/src/dashboard/dataManipulation/__tests__/downloadCsv.test.ts
@@ -3,19 +3,19 @@ import { DurationUnitEnum } from '../../../types';
 
 
 describe('downloadCsv', () => {
-  test('Calls error callback on empty dataset', async () => {
-    const onError = jest.fn();
-    await downloadCsv({
-      data: { groupByX: '', groupByY: '', rows: [] },
-      fromDate: new Date,
-      toDate: new Date,
-      fileName: '',
-      unit: DurationUnitEnum.DAYS,
-      setErrors: onError,
-    });
+  test('Rejects promise with error on empty dataset', async () => {
+    expect.assertions(1);
 
-    expect(onError).toHaveBeenCalledTimes(1);
-    expect(onError)
-      .toHaveBeenLastCalledWith({ Download: 'There is no data available to download' });
+    try {
+      await downloadCsv({
+        data: { groupByX: '', groupByY: '', rows: [] },
+        fromDate: new Date,
+        toDate: new Date,
+        fileName: '',
+        unit: DurationUnitEnum.DAYS,
+      });
+    } catch (error) {
+      expect(error.message).toBe('There was a problem downloading your data');
+    }
   });
 });

--- a/dashboard-app/src/dashboard/dataManipulation/__tests__/downloadCsv.test.ts
+++ b/dashboard-app/src/dashboard/dataManipulation/__tests__/downloadCsv.test.ts
@@ -1,0 +1,21 @@
+import { downloadCsv } from '../downloadCsv';
+import { DurationUnitEnum } from '../../../types';
+
+
+describe('downloadCsv', () => {
+  test('Calls error callback on empty dataset', async () => {
+    const onError = jest.fn();
+    await downloadCsv({
+      data: { groupByX: '', groupByY: '', rows: [] },
+      fromDate: new Date,
+      toDate: new Date,
+      fileName: '',
+      unit: DurationUnitEnum.DAYS,
+      setErrors: onError,
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError)
+      .toHaveBeenLastCalledWith({ Download: 'There is no data available to download' });
+  });
+});

--- a/dashboard-app/src/dashboard/dataManipulation/aggregatedToCsv.ts
+++ b/dashboard-app/src/dashboard/dataManipulation/aggregatedToCsv.ts
@@ -10,7 +10,8 @@ import {
 } from './util';
 import Months from '../../util/months';
 
-const getStringContainingTotal = (xs: string []) => xs.find((x) => x.includes('Total'));
+
+const getStringContainingTotal = (xs: string[]) => xs.find((x) => x.includes('Total'));
 
 // tslint:disable-next-line: max-line-length
 export const aggregatedToCsv = async (data: AggregatedData, unit: DurationUnitEnum): Promise<string> =>

--- a/dashboard-app/src/dashboard/dataManipulation/downloadCsv.ts
+++ b/dashboard-app/src/dashboard/dataManipulation/downloadCsv.ts
@@ -2,8 +2,7 @@ import moment from 'moment';
 import { aggregatedToCsv } from './aggregatedToCsv';
 import Months from '../../util/months';
 import { saveAs } from 'file-saver';
-import { AggregatedData, isDataEmpty } from './logsToAggregatedData';
-import { Dictionary } from 'ramda';
+import { AggregatedData } from './logsToAggregatedData';
 import { DurationUnitEnum } from '../../types';
 
 

--- a/dashboard-app/src/dashboard/dataManipulation/downloadCsv.ts
+++ b/dashboard-app/src/dashboard/dataManipulation/downloadCsv.ts
@@ -12,12 +12,11 @@ interface Params {
   data: AggregatedData;
   fromDate: Date;
   toDate: Date;
-  setErrors: (x: Dictionary<string>) => void;
   unit: DurationUnitEnum;
 }
 
 // tslint:disable-next-line: max-line-length
-export const downloadCsv = async ({ data: aggData, fromDate, toDate, setErrors, fileName, unit }: Params) => {
+export const downloadCsv = async ({ data: aggData, fromDate, toDate, fileName, unit }: Params) => {
   try {
     const csv = await aggregatedToCsv(aggData, unit);
     const from = moment(fromDate).format(Months.format.filename);
@@ -27,10 +26,6 @@ export const downloadCsv = async ({ data: aggData, fromDate, toDate, setErrors, 
     });
     saveAs(file);
   } catch (error) {
-    if (isDataEmpty(aggData)) {
-      setErrors({ Download: 'There is no data available to download' });
-    } else {
-      setErrors({ Download: 'There was a problem downloading your data' });
-    }
+    throw new Error('There was a problem downloading your data');
   }
 };

--- a/dashboard-app/src/dashboard/dataManipulation/downloadCsv.ts
+++ b/dashboard-app/src/dashboard/dataManipulation/downloadCsv.ts
@@ -2,9 +2,10 @@ import moment from 'moment';
 import { aggregatedToCsv } from './aggregatedToCsv';
 import Months from '../../util/months';
 import { saveAs } from 'file-saver';
-import { AggregatedData } from './logsToAggregatedData';
+import { AggregatedData, isDataEmpty } from './logsToAggregatedData';
 import { Dictionary } from 'ramda';
 import { DurationUnitEnum } from '../../types';
+
 
 interface Params {
   fileName: string;
@@ -26,6 +27,10 @@ export const downloadCsv = async ({ data: aggData, fromDate, toDate, setErrors, 
     });
     saveAs(file);
   } catch (error) {
-    setErrors({ Download: 'There was a problem downloading your data' });
+    if (isDataEmpty(aggData)) {
+      setErrors({ Download: 'There is no data available to download' });
+    } else {
+      setErrors({ Download: 'There was a problem downloading your data' });
+    }
   }
 };

--- a/dashboard-app/src/dashboard/dataManipulation/logsToAggregatedData.ts
+++ b/dashboard-app/src/dashboard/dataManipulation/logsToAggregatedData.ts
@@ -22,6 +22,8 @@ export interface AggregatedData {
   rows: Row[];
 }
 
+export const isDataEmpty = (d: AggregatedData) => d.rows.length === 0;
+
 const getIdAndName = (xData: Params['xData'], tableType: TableTypeItem, log: Params['logs']) => {
   switch (tableType.xIdFromLogs){
     case('userId'):


### PR DESCRIPTION
Merge #180 first

### Changes
- Remove 'Download' error message everytime `error`, `fromDate` or `toDate` changes
- Extract `setError` operation to top-level component to avoid passing state setters directly to children

Fixes #177 

NOTE: There is perhaps a concept her calling for a hook called something like `useStateUnless` which sets something in state unless a given condition is satisfied, at which point that value is unset. The API didn't immediately come to me though, so I figured I'd leave it. Something to think about maybe though.