### PR TITLE
📊 reverse order of stack in stacked bar chart

### DIFF
--- a/dashboard-app/src/dashboard/dataManipulation/__tests__/aggregatedToGraphData.test.ts
+++ b/dashboard-app/src/dashboard/dataManipulation/__tests__/aggregatedToGraphData.test.ts
@@ -28,16 +28,16 @@ describe('aggregatedToGraphData', () => {
     expect(expected).toEqual({
       datasets: [
         {
-          backgroundColor: '#F44336',
-          data: [0, 0.03, 0],
-          label: 'Digging Holes',
-          id: 3,
-        },
-        {
           backgroundColor: '#E91E63',
           data: [0, 2.38, 2],
           label: 'Outdoor and practical work',
           id: 5,
+        },
+        {
+          backgroundColor: '#F44336',
+          data: [0, 0.03, 0],
+          label: 'Digging Holes',
+          id: 3,
         },
       ],
       labels: [['Feb', '2018'], ['Mar', '2018'], ['Apr', '2018']],

--- a/dashboard-app/src/dashboard/dataManipulation/aggregatedToGraphData.ts
+++ b/dashboard-app/src/dashboard/dataManipulation/aggregatedToGraphData.ts
@@ -24,6 +24,8 @@ export const aggregatedToStackedGraph = (data: AggregatedData, unit: DurationUni
         id: row.id,
         data: labels.map((y) => numericData[y]),
       };
-    }),
+    })
+    // display stacks in same colour order as legend
+    .reverse(),
   };
 };


### PR DESCRIPTION
**Changes**
- display colours in the same order as legend

fixes #171 