### PR TITLE
🐛 prevent 500 error on login when user has no password

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1005,9 +1005,9 @@
       "integrity": "sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA=="
     },
     "@types/ramda": {
-      "version": "0.26.12",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.26.12.tgz",
-      "integrity": "sha512-1cIbhPNoG8VGgmwk/Izoq8iImXdM0RWuY8MFHHxSuFqxww1v+WI1kl7a0IeTUDcDjON+lqXMF1Bw+OZUss0Bqg=="
+      "version": "0.26.14",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.26.14.tgz",
+      "integrity": "sha512-OKSReh+kGIPiLzYnQIdAtrdE0w1lW1dnTsdFtbVYEj8kWdYKpolF+bZAvHaNCiTq2C91iwGJ/7q81DOjRQOHrw=="
     },
     "@types/shot": {
       "version": "4.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -67,7 +67,7 @@
     "@types/minimist": "^1.2.0",
     "@types/pdfmake": "^0.1.3",
     "@types/qs": "^6.5.3",
-    "@types/ramda": "^0.26.12",
+    "@types/ramda": "^0.26.14",
     "axios": "^0.19.0",
     "bcrypt": "^3.0.6",
     "chalk": "^2.4.2",

--- a/api/src/api/v1/users/__tests__/login.test.integration.ts
+++ b/api/src/api/v1/users/__tests__/login.test.integration.ts
@@ -170,13 +170,18 @@ describe('POST /users/login', () => {
       url: '/v1/users/login',
       payload: {
         restrict: ['VOLUNTEER'],
-        email: '1498@aperturescience.com',
+        email: '1498@aperturescience.com', // This is VISITOR!
         password: 'CakeisaLi3!',
       },
     });
 
     expect(res.statusCode).toBe(403);
     expect(typeof res.headers['set-cookie']).toBe('undefined');
-    expect(res.result).toEqual({ error: expect.objectContaining({ statusCode: 403 }) });
+    expect(res.result).toEqual({
+      error: expect.objectContaining({
+        statusCode: 403,
+        message: 'User does not have required role',
+      }),
+    });
   });
 });

--- a/api/src/api/v1/users/__tests__/login.test.integration.ts
+++ b/api/src/api/v1/users/__tests__/login.test.integration.ts
@@ -163,4 +163,20 @@ describe('POST /users/login', () => {
     expect(typeof res.headers['set-cookie']).toBe('undefined');
     expect(res.result).toEqual({ error: expect.objectContaining({ statusCode: 400 }) });
   });
+
+  test(':: unsuccessful login | type body | mismatched role', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/v1/users/login',
+      payload: {
+        restrict: ['VOLUNTEER'],
+        email: '1498@aperturescience.com',
+        password: 'CakeisaLi3!',
+      },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(typeof res.headers['set-cookie']).toBe('undefined');
+    expect(res.result).toEqual({ error: expect.objectContaining({ statusCode: 403 }) });
+  });
 });


### PR DESCRIPTION
Moving the role check before the payload check prevents this error.

Fixes #88 