### PR TITLE
🐛 disallow CB_ADMIN from adding own logs

### DIFF
--- a/api/database/index.ts
+++ b/api/database/index.ts
@@ -44,7 +44,7 @@ export const migrate = {
     const config = getConfig(env);
     const _client = client ? client : Knex(config.knex);
 
-    console.log(`Tearing down the "${config.env}" database\n`);
+    console.log(`\nTearing down the "${config.env}" database\n`);
 
     const tables = await _client('pg_catalog.pg_tables')
       .select('tablename')

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1005,9 +1005,9 @@
       "integrity": "sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA=="
     },
     "@types/ramda": {
-      "version": "0.26.12",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.26.12.tgz",
-      "integrity": "sha512-1cIbhPNoG8VGgmwk/Izoq8iImXdM0RWuY8MFHHxSuFqxww1v+WI1kl7a0IeTUDcDjON+lqXMF1Bw+OZUss0Bqg=="
+      "version": "0.26.14",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.26.14.tgz",
+      "integrity": "sha512-OKSReh+kGIPiLzYnQIdAtrdE0w1lW1dnTsdFtbVYEj8kWdYKpolF+bZAvHaNCiTq2C91iwGJ/7q81DOjRQOHrw=="
     },
     "@types/shot": {
       "version": "4.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -67,7 +67,7 @@
     "@types/minimist": "^1.2.0",
     "@types/pdfmake": "^0.1.3",
     "@types/qs": "^6.5.3",
-    "@types/ramda": "^0.26.12",
+    "@types/ramda": "^0.26.14",
     "axios": "^0.19.0",
     "bcrypt": "^3.0.6",
     "chalk": "^2.4.2",

--- a/api/src/api/v1/community_businesses/__tests__/volunteer_logs.test.integration.ts
+++ b/api/src/api/v1/community_businesses/__tests__/volunteer_logs.test.integration.ts
@@ -355,7 +355,7 @@ describe('API /community-businesses/me/volunteer-logs', () => {
   });
 
   describe('POST /community-businesses/me/volunteer-logs', () => {
-    test('SUCCESS - can create log for own user', async () => {
+    test('SUCCESS - can create log for own volunteer user', async () => {
       const when = new Date();
 
       const resCount1 = await server.inject(injectCfg({
@@ -465,6 +465,20 @@ describe('API /community-businesses/me/volunteer-logs', () => {
         credentials: volCreds,
         payload: {
           userId: user.id,
+          activity: 'Office support',
+          duration: { minutes: 20, hours: 2 },
+        },
+      }));
+
+      expect(res.statusCode).toBe(403);
+    });
+
+    test('ERROR - cannot create log for self if admin at CB', async () => {
+      const res = await server.inject(injectCfg({
+        method: 'POST',
+        url: '/v1/community-businesses/me/volunteer-logs',
+        credentials: adminCreds,
+        payload: {
           activity: 'Office support',
           duration: { minutes: 20, hours: 2 },
         },

--- a/api/src/api/v1/community_businesses/volunteer_logs.ts
+++ b/api/src/api/v1/community_businesses/volunteer_logs.ts
@@ -264,6 +264,16 @@ const routes: Hapi.ServerRoute[] = [
         if (!hasPermission) {
           return Boom.forbidden('Insufficient permission');
         }
+      } else {
+        const isVolunteer = await Roles.userHasAtCb(knex, {
+          userId: user.id,
+          organisationId: communityBusiness.id,
+          role: [RoleEnum.VOLUNTEER, RoleEnum.VOLUNTEER_ADMIN],
+        });
+
+        if (!isVolunteer) {
+          return Boom.forbidden('Only volunteers may add logs');
+        }
       }
 
       try {


### PR DESCRIPTION
fixes #61 

Just add a role check if `userId === 'me'`, allowing only `VOLUNTEER` and `VOLUNTEER_ADMIN` users.