### PR TITLE
🔬 allow onChangeSortBy to return default sort order to address QA defect

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1005,9 +1005,9 @@
       "integrity": "sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA=="
     },
     "@types/ramda": {
-      "version": "0.26.14",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.26.14.tgz",
-      "integrity": "sha512-OKSReh+kGIPiLzYnQIdAtrdE0w1lW1dnTsdFtbVYEj8kWdYKpolF+bZAvHaNCiTq2C91iwGJ/7q81DOjRQOHrw=="
+      "version": "0.26.15",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.26.15.tgz",
+      "integrity": "sha512-kmIO8GVOLv0A8UxFr5lJaqp4g8jbXNhH0grBaPL6NgkOqSirRKpV9+5DTmIDXTyq2G18YMdxDhnScEZtY4brtQ=="
     },
     "@types/shot": {
       "version": "4.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -67,7 +67,7 @@
     "@types/minimist": "^1.2.0",
     "@types/pdfmake": "^0.1.3",
     "@types/qs": "^6.5.3",
-    "@types/ramda": "^0.26.14",
+    "@types/ramda": "^0.26.15",
     "axios": "^0.19.0",
     "bcrypt": "^3.0.6",
     "chalk": "^2.4.2",

--- a/dashboard-app/src/features/dashboard/ByActivity/__tests__/index.test.ts
+++ b/dashboard-app/src/features/dashboard/ByActivity/__tests__/index.test.ts
@@ -1,10 +1,11 @@
-import { cleanup, waitForElement } from 'react-testing-library';
+import { cleanup, waitForElement, fireEvent } from 'react-testing-library';
 import MockAdapter from 'axios-mock-adapter';
 import { renderWithHistory } from '../../../../lib/util/tests';
 import { axios } from '../../../../lib/api';
 import { logs, users, activities } from '../../__data__/api_data';
 import ByActivity from '../../ByActivity';
 import 'jest-dom/extend-expect';
+
 
 describe('By Activity Page', () => {
   let mock: MockAdapter;
@@ -15,7 +16,7 @@ describe('By Activity Page', () => {
 
   afterEach(cleanup);
 
-  test('Success :: Display title and empty table', async () => {
+  test('Display title and empty table', async () => {
     expect.assertions(2);
 
     mock.onGet('/community-businesses/me/volunteer-logs').reply(200, { result: [] });
@@ -29,11 +30,11 @@ describe('By Activity Page', () => {
       tools.getByText('AVAILABLE', { exact: false }),
     ]);
 
-    expect(title.textContent).toBe('By Activity');
-    expect(message.textContent).toBe('NO DATA AVAILABLE');
+    expect(title).toHaveTextContent('By Activity');
+    expect(message).toHaveTextContent('NO DATA AVAILABLE');
   });
 
-  test('Success :: Render data to table', async () => {
+  test('Render data to table', async () => {
     expect.assertions(1);
 
     mock.onGet('/community-businesses/me/volunteer-logs').reply(200, { result: logs });
@@ -50,6 +51,30 @@ describe('By Activity Page', () => {
       tools.getByText('Wilma', { exact: true }),
     ]);
 
-    expect(title.textContent).toBe('By Activity');
+    expect(title).toHaveTextContent('By Activity');
+  });
+
+  test('Sort on first column is ascending (A-Z) by default', async () => {
+    expect.assertions(4);
+
+    mock.onGet('/community-businesses/me/volunteer-logs').reply(200, { result: logs });
+    mock.onGet('/community-businesses/me/volunteers').reply(200, { result: users });
+    mock.onGet('/volunteer-activities').reply(200, { result: activities });
+
+    const tools = renderWithHistory(ByActivity);
+
+    const header = await waitForElement(() => tools.getByText('Volunteer Name', { exact: true }));
+
+    fireEvent.click(header);
+
+    const [sortedHeader, rows] = await waitForElement(() => [
+      tools.getByText('Volunteer Name', { exact: false }),
+      tools.getAllByTestId('data-table-row'),
+    ]);
+
+    expect(sortedHeader.textContent).toBe('↑ Volunteer Name');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent('Betty3.3321.33');
+    expect(rows[1]).toHaveTextContent('Wilma3.673.670');
   });
 });

--- a/dashboard-app/src/features/dashboard/ByActivity/index.tsx
+++ b/dashboard-app/src/features/dashboard/ByActivity/index.tsx
@@ -18,7 +18,6 @@ import useAggregateDataByActivity from './useAggregateDataByActivity';
 import { TabGroup } from '../components/Tabs';
 import { getTitleForDayPicker } from '../util';
 import { useErrors } from '../../../lib/hooks/useErrors';
-import { Order } from 'twine-util/arrays';
 
 
 /**

--- a/dashboard-app/src/features/dashboard/ByActivity/index.tsx
+++ b/dashboard-app/src/features/dashboard/ByActivity/index.tsx
@@ -18,6 +18,7 @@ import useAggregateDataByActivity from './useAggregateDataByActivity';
 import { TabGroup } from '../components/Tabs';
 import { getTitleForDayPicker } from '../util';
 import { useErrors } from '../../../lib/hooks/useErrors';
+import { Order } from 'twine-util/arrays';
 
 
 /**
@@ -70,6 +71,13 @@ const ByActivity: FunctionComponent<RouteComponentProps> = (props) => {
     const idx = tableData.headers.indexOf(column);
     if (idx > -1) {
       setSortBy(idx);
+
+      // Requirement: If column being selected for sorting is "Volunteer Name"
+      //              (i.e. the first column), sort ascending (A-Z) instead of
+      //              descending (Z-A)
+      if (idx === 0) {
+        return 'asc';
+      }
     }
   }, [tableData]);
 

--- a/dashboard-app/src/features/dashboard/ByTime/__tests__/index.test.ts
+++ b/dashboard-app/src/features/dashboard/ByTime/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, waitForElement, fireEvent } from 'react-testing-library';
+import { cleanup, waitForElement, fireEvent, wait } from 'react-testing-library';
 import MockAdapter from 'axios-mock-adapter';
 import MockDate from 'mockdate';
 import { renderWithHistory } from '../../../../lib/util/tests';
@@ -83,6 +83,36 @@ describe('By Time Page', () => {
       expect(rows[0]).toHaveTextContent('Cafe5.6600020.333.33000000');
       expect(rows[1]).toHaveTextContent('Running away1.3300000001.330000');
       expect(firstHeader).toHaveTextContent('↑ Activity');
+    });
+
+    test('Sort on first column is ascending (A-Z) by default', async () => {
+      expect.assertions(4);
+
+      mock.onGet('/community-businesses/me/volunteer-logs').reply(200, { result: logs });
+      mock.onGet('/volunteer-activities').reply(200, { result: activities });
+
+      const tools = renderWithHistory(ByTime);
+      const tableTab = await waitForElement(() => tools.getByText('Table', { exact: true }));
+      fireEvent.click(tableTab);
+
+      const [header1, header2] = await waitForElement(() => [
+        tools.getByText('↑ Activity', { exact: true }),
+        tools.getByText('Total Hours', { exact: true }),
+      ]);
+
+      fireEvent.click(header2);
+      await wait();
+      fireEvent.click(header1);
+
+      const [sortedHeader, rows] = await waitForElement(() => [
+        tools.getByText('↑ Activity', { exact: true }),
+        tools.getAllByTestId('data-table-row'),
+      ]);
+
+      expect(sortedHeader).toHaveTextContent('↑ Activity');
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toHaveTextContent('Cafe5.6600020.333.33000000');
+      expect(rows[1]).toHaveTextContent('Running away1.3300000001.330000');
     });
   });
 

--- a/dashboard-app/src/features/dashboard/ByTime/index.tsx
+++ b/dashboard-app/src/features/dashboard/ByTime/index.tsx
@@ -59,6 +59,13 @@ const ByTime: FunctionComponent<RouteComponentProps> = (props) => {
     const idx = tableData.headers.indexOf(column);
     if (idx > -1) {
       setSortBy(idx);
+
+      // Requirement: If column being selected for sorting is "Volunteer Name"
+      //              (i.e. the first column), sort ascending (A-Z) instead of
+      //              descending (Z-A)
+      if (idx === 0) {
+        return 'asc';
+      }
     }
   }, [tableData]);
 

--- a/dashboard-app/src/features/dashboard/ByVolunteer/__tests__/index.test.ts
+++ b/dashboard-app/src/features/dashboard/ByVolunteer/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, waitForElement, fireEvent } from 'react-testing-library';
+import { cleanup, waitForElement, fireEvent, wait } from 'react-testing-library';
 import MockAdapter from 'axios-mock-adapter';
 import MockDate from 'mockdate';
 import { renderWithHistory } from '../../../../lib/util/tests';
@@ -85,6 +85,36 @@ describe('By Volunteer Page', () => {
       expect(rows[0]).toHaveTextContent('Wilma3.6600000.333.33000000');
       expect(rows[1]).toHaveTextContent('Betty3.3300020001.330000');
       expect(sortedHeader).toHaveTextContent('↓ Total Hours');
+    });
+
+    test('Sort on first column is ascending (A-Z) by default', async () => {
+      expect.assertions(4);
+
+      mock.onGet('/community-businesses/me/volunteer-logs').reply(200, { result: logs });
+      mock.onGet('/community-businesses/me/volunteers').reply(200, { result: users });
+
+      const tools = renderWithHistory(ByVolunteer);
+      const tableTab = await waitForElement(() => tools.getByText('Table', { exact: true }));
+      fireEvent.click(tableTab);
+
+      const [header1, header2] = await waitForElement(() => [
+        tools.getByText('Volunteer Name', { exact: true }),
+        tools.getByText('Total Hours', { exact: false }),
+      ]);
+
+      fireEvent.click(header2);
+      await wait();
+      fireEvent.click(header1);
+
+      const [sortedHeader, rows] = await waitForElement(() => [
+        tools.getByText('Volunteer Name', { exact: false }),
+        tools.getAllByTestId('data-table-row'),
+      ]);
+
+      expect(sortedHeader).toHaveTextContent('↑ Volunteer Name');
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toHaveTextContent('Betty3.3300020001.330000');
+      expect(rows[1]).toHaveTextContent('Wilma3.6600000.333.33000000');
     });
   });
 });

--- a/dashboard-app/src/features/dashboard/ByVolunteer/index.tsx
+++ b/dashboard-app/src/features/dashboard/ByVolunteer/index.tsx
@@ -59,6 +59,13 @@ const ByVolunteer: FunctionComponent<RouteComponentProps> = (props) => {
     if (idx > -1) {
       setSortBy(idx);
     }
+
+    // Requirement: If column being selected for sorting is "Volunteer Name"
+    //              (i.e. the first column), sort ascending (A-Z) instead of
+    //              descending (Z-A)
+    if (idx === 0) {
+      return 'asc';
+    }
   }, [tableData]);
 
   const downloadAsCsv = useCallback(() => {

--- a/dashboard-app/src/features/dashboard/components/DataTable/index.tsx
+++ b/dashboard-app/src/features/dashboard/components/DataTable/index.tsx
@@ -63,8 +63,8 @@ const DataTable: React.FunctionComponent<DataTableProps> = (props) => {
     if (sortBy === title) { // toggling order
       setOrder(order === 'desc' ? 'asc' : 'desc');
     } else { // sorting by new column
-      onChangeSortBy(title);
-      setOrder('desc');
+      const order = onChangeSortBy(title);
+      setOrder(order || 'desc');
     }
   }, [order, sortBy, headers]);
 

--- a/dashboard-app/src/features/dashboard/components/DataTable/types.ts
+++ b/dashboard-app/src/features/dashboard/components/DataTable/types.ts
@@ -15,7 +15,7 @@ export type DataTableProps = {
   headers: string[]
   initialOrder?: Order
   sortBy?: string
-  onChangeSortBy?: (s: string) => void
+  onChangeSortBy?: (s: string) => Order | void
   rows: DataTableRow[]
   showTotals?: boolean
 };


### PR DESCRIPTION
related to #98 

Allow `onChangeSortBy` to return default sort order.