### PR TITLE
↕ CSV sorting

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1005,9 +1005,9 @@
       "integrity": "sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA=="
     },
     "@types/ramda": {
-      "version": "0.26.14",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.26.14.tgz",
-      "integrity": "sha512-OKSReh+kGIPiLzYnQIdAtrdE0w1lW1dnTsdFtbVYEj8kWdYKpolF+bZAvHaNCiTq2C91iwGJ/7q81DOjRQOHrw=="
+      "version": "0.26.15",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.26.15.tgz",
+      "integrity": "sha512-kmIO8GVOLv0A8UxFr5lJaqp4g8jbXNhH0grBaPL6NgkOqSirRKpV9+5DTmIDXTyq2G18YMdxDhnScEZtY4brtQ=="
     },
     "@types/shot": {
       "version": "4.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -67,7 +67,7 @@
     "@types/minimist": "^1.2.0",
     "@types/pdfmake": "^0.1.3",
     "@types/qs": "^6.5.3",
-    "@types/ramda": "^0.26.14",
+    "@types/ramda": "^0.26.15",
     "axios": "^0.19.0",
     "bcrypt": "^3.0.6",
     "chalk": "^2.4.2",

--- a/api/src/models/community_business.ts
+++ b/api/src/models/community_business.ts
@@ -25,10 +25,18 @@ import {
   VisitEvent,
   RegionEnum,
   SectorEnum,
+  VisitActivity,
 } from './types';
 import { Organisations } from './organisation';
 import { AgeList } from './age';
 import { applyQueryModifiers } from './applyQueryModifiers';
+
+const renameKeysToColumns = Objects.renameKeys({
+  name: 'visit_activity_name',
+  category: 'visit_activity_category_id',
+  createdAt: 'created_at',
+  modifiedAt: 'modified_at',
+});
 
 
 /*
@@ -426,12 +434,7 @@ export const CommunityBusinesses: CommunityBusinessCollection = {
             .select('visit_activity_category_id')
             .where({ visit_activity_category_name: n }),
       }),
-      Objects.renameKeys({
-        name: 'visit_activity_name',
-        category: 'visit_activity_category_id',
-        createdAt: 'created_at',
-        modifiedAt: 'modified_at',
-      }),
+      (v: Omit<VisitActivity, 'id'>) => renameKeysToColumns<string | boolean>(v),
       omit(['id'])
     );
 

--- a/api/src/models/user.ts
+++ b/api/src/models/user.ts
@@ -5,7 +5,7 @@ import * as Knex from 'knex';
 import { compose, omit, filter, pick, invertObj, evolve } from 'ramda';
 import { hash } from 'bcrypt';
 import { Objects } from 'twine-util';
-import { Map } from '../types/internal';
+import { Map, Dictionary } from '../types/internal';
 import {
   User,
   UserRow,
@@ -213,7 +213,7 @@ export const Users: UserCollection = {
   async destroy (client, user) {
     const preProcessUser = compose(
       transformForeignKeysToSubQueries(client),
-      replaceConstantsWithForeignKeys,
+      (a: Dictionary<any>) => replaceConstantsWithForeignKeys<any>(a),
       Users.toColumnNames,
       dropUnwhereableUserFields
     );

--- a/api/src/models/volunteer_log.ts
+++ b/api/src/models/volunteer_log.ts
@@ -193,7 +193,7 @@ export const VolunteerLogs: VolunteerLogCollection = {
   async destroy (client, log) {
     const preProcessLog = compose(
       transformForeignKeysToSubQueries(client, log.organisationId),
-      replaceConstantsWithForeignKeys,
+      (a: Dictionary<any>) => replaceConstantsWithForeignKeys<any>(a),
       VolunteerLogs.toColumnNames,
       dropUnwhereableUserFields
     );

--- a/dashboard-app/src/features/dashboard/ByActivity/index.tsx
+++ b/dashboard-app/src/features/dashboard/ByActivity/index.tsx
@@ -75,7 +75,8 @@ const ByActivity: FunctionComponent<RouteComponentProps> = (props) => {
 
   const downloadAsCsv = useCallback(() => {
     if (!loading && data) {
-      downloadCsv({ data, fromDate, toDate, setErrors, fileName: 'by_activity', unit });
+      downloadCsv({ data, fromDate, toDate, fileName: 'by_activity', unit, sortBy })
+        .catch((error) => setErrors({ Download: error.message }));
     } else {
       setErrors({ Download: 'No data available to download' });
     }

--- a/dashboard-app/src/features/dashboard/ByTime/index.tsx
+++ b/dashboard-app/src/features/dashboard/ByTime/index.tsx
@@ -64,7 +64,8 @@ const ByTime: FunctionComponent<RouteComponentProps> = (props) => {
 
   const downloadAsCsv = useCallback(() => {
     if (!loading && data) {
-      downloadCsv({ data, fromDate, toDate, setErrors, fileName: 'by_time', unit });
+      downloadCsv({ data, fromDate, toDate, fileName: 'by_time', unit, sortBy })
+        .catch((error) => setErrors({ Download: error.message }));
     } else {
       setErrors({ Download: 'No data available to download' });
     }

--- a/dashboard-app/src/features/dashboard/ByVolunteer/index.tsx
+++ b/dashboard-app/src/features/dashboard/ByVolunteer/index.tsx
@@ -63,7 +63,8 @@ const ByVolunteer: FunctionComponent<RouteComponentProps> = (props) => {
 
   const downloadAsCsv = useCallback(() => {
     if (!loading && data) {
-      downloadCsv({ data, fromDate, toDate, setErrors, fileName: 'by_volunteer', unit });
+      downloadCsv({ data, fromDate, toDate, fileName: 'by_volunteer', unit, sortBy })
+        .catch((error) => setErrors({ Download: error.message }));
     } else {
       setErrors({ Download: 'No data available to download' });
     }

--- a/dashboard-app/src/features/dashboard/dataManipulation/__tests__/downloadCsv.test.ts
+++ b/dashboard-app/src/features/dashboard/dataManipulation/__tests__/downloadCsv.test.ts
@@ -3,19 +3,19 @@ import { DurationUnitEnum } from '../../../../types';
 
 
 describe('downloadCsv', () => {
-  test('Calls error callback on empty dataset', async () => {
-    const onError = jest.fn();
-    await downloadCsv({
+  test('Throws on empty dataset', async () => {
+    expect.assertions(1);
+
+    downloadCsv({
       data: { groupByX: '', groupByY: '', rows: [] },
       fromDate: new Date,
       toDate: new Date,
       fileName: '',
       unit: DurationUnitEnum.DAYS,
-      setErrors: onError,
-    });
-
-    expect(onError).toHaveBeenCalledTimes(1);
-    expect(onError)
-      .toHaveBeenLastCalledWith({ Download: 'There is no data available to download' });
+      sortBy: 0,
+    })
+      .catch((error) => {
+        expect(error.message).toBe('No data available to download');
+      });
   });
 });

--- a/dashboard-app/src/features/dashboard/dataManipulation/downloadCsv.ts
+++ b/dashboard-app/src/features/dashboard/dataManipulation/downloadCsv.ts
@@ -12,16 +12,15 @@ interface Params {
   data: AggregatedData;
   fromDate: Date;
   toDate: Date;
-  setErrors: (x: Dictionary<string>) => void;
   unit: DurationUnitEnum;
 }
 
 // tslint:disable-next-line: max-line-length
-export const downloadCsv = async ({ data: aggData, fromDate, toDate, setErrors, fileName, unit }: Params) => {
+export const downloadCsv = async ({ data: aggData, fromDate, toDate, fileName, unit }: Params) => {
   if (isDataEmpty(aggData)) {
-    setErrors({ Download: 'There is no data available to download' });
-    return;
+    throw new Error('No data available to download');
   }
+
   try {
     const csv = await aggregatedToCsv(aggData, unit);
     const from = moment(fromDate).format(Months.format.filename);
@@ -30,7 +29,9 @@ export const downloadCsv = async ({ data: aggData, fromDate, toDate, setErrors, 
       type: 'text/plain;charset=utf-8',
     });
     saveAs(file);
+
   } catch (error) {
-    setErrors({ Download: 'There was a problem downloading your data' });
+    throw new Error('There was a problem downloading your data');
+
   }
 };

--- a/dashboard-app/src/features/dashboard/dataManipulation/downloadCsv.ts
+++ b/dashboard-app/src/features/dashboard/dataManipulation/downloadCsv.ts
@@ -3,7 +3,6 @@ import { aggregatedToCsv } from './aggregatedToCsv';
 import Months from '../../../lib/util/months';
 import { saveAs } from 'file-saver';
 import { AggregatedData, isDataEmpty } from './logsToAggregatedData';
-import { Dictionary } from 'ramda';
 import { DurationUnitEnum } from '../../../types';
 
 
@@ -13,16 +12,17 @@ interface Params {
   fromDate: Date;
   toDate: Date;
   unit: DurationUnitEnum;
+  sortBy: number;
 }
 
 // tslint:disable-next-line: max-line-length
-export const downloadCsv = async ({ data: aggData, fromDate, toDate, fileName, unit }: Params) => {
+export const downloadCsv = async ({ data: aggData, fromDate, toDate, fileName, unit, sortBy }: Params) => {
   if (isDataEmpty(aggData)) {
     throw new Error('No data available to download');
   }
 
   try {
-    const csv = await aggregatedToCsv(aggData, unit);
+    const csv = await aggregatedToCsv(aggData, unit, sortBy);
     const from = moment(fromDate).format(Months.format.filename);
     const to = moment(toDate).format(Months.format.filename);
     const file = new File([csv], `${fileName}_${from}-${to}.csv`, {

--- a/dashboard-app/src/features/dashboard/dataManipulation/logsToAggregatedData.ts
+++ b/dashboard-app/src/features/dashboard/dataManipulation/logsToAggregatedData.ts
@@ -15,7 +15,7 @@ interface Params {
   yData: IdAndName[];
 }
 
-export type Row = Dictionary<string | Duration.Duration> & {};
+export type Row = Dictionary<string | Duration.Duration>;
 export interface AggregatedData {
   groupByX: string;
   groupByY: string;

--- a/dashboard-app/src/features/dashboard/dataManipulation/util.ts
+++ b/dashboard-app/src/features/dashboard/dataManipulation/util.ts
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { evolve, curry, omit, map, pipe, toPairs, fromPairs } from 'ramda';
+import { evolve, curry, omit, Dictionary } from 'ramda';
 import { Duration, MathUtil, Objects } from 'twine-util';
 import { DurationUnitEnum } from '../../../types';
 import { AggregatedData } from './logsToAggregatedData';
@@ -46,10 +46,10 @@ export const calculateTotalsUsing = (unit: DurationUnitEnum) => evolve({
   headers: ([first, ...rest]: string[]) => [first, `Total ${unit}`, ...rest],
   rows: (rows: AggregatedData['rows']) => rows.map((row) => {
     const _row = Objects.mapValues((v) => typeof v === 'object' ? toUnitDuration(unit, v) : v, row);
-    return {
-      ..._row,
-      [`Total ${unit}`]: round(Objects.reduceValues(add, 0, _row)),
-    };
+    return Object.assign(
+      { [`Total ${unit}`]: round(Objects.reduceValues(add, 0, _row)) },
+      _row
+    );
   }),
 });
 
@@ -64,10 +64,7 @@ export const removeIdInRows = (data: AggregatedData) => {
 }; // TODO: add test
 
 export const abbreviateMonths = (format: MonthsFormatEnum) => evolve({
-  headers: map((x) => abbreviateIfDateString(format, x)),
-  rows: pipe(
-    map(toPairs as any),
-    map(map(map((x) => abbreviateIfDateString(format, x)))) as any,
-    map(fromPairs)
-  ),
+  headers: (headers: string[]) => headers.map((x) => abbreviateIfDateString(format, x)),
+  rows: (rows: Dictionary<string | number>[]) => rows
+    .map((row) => Objects.mapKeys((k) => abbreviateIfDateString(format, k))(row)),
 }); // TODO: add test

--- a/lib/twine-util/arrays.ts
+++ b/lib/twine-util/arrays.ts
@@ -1,4 +1,4 @@
-import { identity, descend, ascend, sortWith, path } from 'ramda';
+import { identity, descend, ascend, sortWith } from 'ramda';
 
 
 /**

--- a/lib/twine-util/objects.ts
+++ b/lib/twine-util/objects.ts
@@ -21,8 +21,8 @@ export const mapValues =
     Object.keys(o).reduce((acc, k) => assoc(k, f(o[k]), acc), {} as Dictionary<U>);
 
 export const renameKeys =
-  (map: Dictionary<string>) => (o: Dictionary<any>) =>
-    Object.keys(o).reduce((acc, k) => assoc(map[k] || k, o[k], acc), {} as Dictionary<any>);
+  (map: Dictionary<string>) => <T>(o: Dictionary<T>) =>
+    Object.keys(o).reduce((acc, k) => assoc(map[k] || k, o[k], acc), {} as Dictionary<T>);
 
 export const evolveKeys = <T>(map: Dictionary<((a: string) => string)>, o: Dictionary<T>) =>
   Object.keys(o)


### PR DESCRIPTION
fixes #98 

- CSV sorting matches (initial) table sorting. 
  - Specifically, if user has changed the initial order from 'asc' -> 'desc' or vice-versa, it doesn't reflect this change.
- `downloadCsv` throws errors now -- reducing its responsibility
- Download errors are now managed in the top-level component.
- Improve type inference in `dataManipulation/util` and `twine-util`.