### PR TITLE
🐛 fix dashboard tile truncation logic

### DIFF
--- a/dashboard-app/src/features/dashboard/Dashboard/__tests__/useDashboardStatistics.test.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/__tests__/useDashboardStatistics.test.ts
@@ -26,7 +26,12 @@ describe('timeStatsToProps', () => {
   test('one data point', () => {
     expect(timeStatsToProps({ labels: ['foo'], value: 10 })).toEqual({
       topText: ['Over the past ', '12 months'],
-      left: { label: 'Most volunteer days were in', data: ['foo'], limit: 3, truncationString: '...' },
+      left: {
+        label: 'Most volunteer days were in',
+        data: ['foo'],
+        limit: 3,
+        truncationString: '...',
+      },
       right: { label: 'hours', data: 10 },
     });
   });
@@ -162,7 +167,12 @@ describe('activityStatsToProps', () => {
   test('one data point', () => {
     expect(activityStatsToProps({ labels: ['foo'], value: 10 })).toEqual({
       topText: ['During ', moment().format('MMM YYYY')],
-      left: { label: 'Most popular activity was', data: ['foo'], limit: 2, truncationString: '...' },
+      left: {
+        label: 'Most popular activity was',
+        data: ['foo'],
+        limit: 2,
+        truncationString: '...',
+      },
       right: { label: 'hours', data: 10 },
     });
   });

--- a/dashboard-app/src/features/dashboard/Dashboard/__tests__/useDashboardStatistics.test.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/__tests__/useDashboardStatistics.test.ts
@@ -18,7 +18,7 @@ describe('timeStatsToProps', () => {
   test('zero data points', () => {
     expect(timeStatsToProps({ labels: [], value: 0 })).toEqual({
       topText: ['Over the past ', '12 months'],
-      left: { label: 'No data available', data: [], limit: 3, placeholder: '...' },
+      left: { label: 'No data available', data: [], limit: 3, truncationString: '...' },
       right: { label: 'hours', data: 0 },
     });
   });
@@ -26,7 +26,7 @@ describe('timeStatsToProps', () => {
   test('one data point', () => {
     expect(timeStatsToProps({ labels: ['foo'], value: 10 })).toEqual({
       topText: ['Over the past ', '12 months'],
-      left: { label: 'Most volunteer days were in', data: ['foo'], limit: 3, placeholder: '...' },
+      left: { label: 'Most volunteer days were in', data: ['foo'], limit: 3, truncationString: '...' },
       right: { label: 'hours', data: 10 },
     });
   });
@@ -38,7 +38,7 @@ describe('timeStatsToProps', () => {
         label: 'Most volunteer days were in',
         data: ['foo', 'bar'],
         limit: 3,
-        placeholder: '...',
+        truncationString: '...',
       },
       right: { label: 'hours each', data: 10 },
     });
@@ -51,7 +51,7 @@ describe('timeStatsToProps', () => {
         label: 'Most volunteer days were in',
         data: ['foo', 'bar', 'woo'],
         limit: 3,
-        placeholder: '...',
+        truncationString: '...',
       },
       right: { label: 'hours each', data: 10 },
     });
@@ -64,7 +64,7 @@ describe('timeStatsToProps', () => {
         label: 'Most volunteer days were in',
         data: ['foo', 'bar', 'woo', 'war'],
         limit: 3,
-        placeholder: '...',
+        truncationString: '...',
       },
       right: { label: 'hours each', data: 10 },
     });
@@ -84,7 +84,7 @@ describe('volunteerStatsToProps', () => {
     expect(volunteerStatsToProps({ labels: [], value: 0 })).toEqual({
       topText: ['During ', moment().format('MMM YYYY')],
       left: { label: 'No data available', data: [] },
-      right: { label: '0 hours', data: [], limit: 3, placeholder: '...' },
+      right: { label: '0 hours', data: [], limit: 3, truncationString: '...' },
     });
   });
 
@@ -92,7 +92,7 @@ describe('volunteerStatsToProps', () => {
     expect(volunteerStatsToProps({ labels: ['foo'], value: 10 })).toEqual({
       topText: ['During ', moment().format('MMM YYYY')],
       left: { label: 'Top volunteer', data: [] },
-      right: { label: '10 hours', data: ['foo'], limit: 3, placeholder: '...' },
+      right: { label: '10 hours', data: ['foo'], limit: 3, truncationString: '...' },
     });
   });
 
@@ -107,7 +107,7 @@ describe('volunteerStatsToProps', () => {
         label: '10 hours each',
         data: ['foo', 'bar'],
         limit: 3,
-        placeholder: '...', },
+        truncationString: '...', },
     });
   });
 
@@ -122,7 +122,7 @@ describe('volunteerStatsToProps', () => {
         label: '10 hours each',
         data: ['foo', 'bar', 'woo'],
         limit: 3,
-        placeholder: '...', },
+        truncationString: '...', },
     });
   });
 
@@ -137,7 +137,7 @@ describe('volunteerStatsToProps', () => {
         label: '10 hours each',
         data: ['foo', 'bar', 'woo', 'war'],
         limit: 3,
-        placeholder: '...', },
+        truncationString: '...', },
     });
   });
 });
@@ -154,7 +154,7 @@ describe('activityStatsToProps', () => {
   test('zero data points', () => {
     expect(activityStatsToProps({ labels: [], value: 0 })).toEqual({
       topText: ['During ', moment().format('MMM YYYY')],
-      left: { label: 'No data available', data: [], limit: 2, placeholder: '...' },
+      left: { label: 'No data available', data: [], limit: 2, truncationString: '...' },
       right: { label: 'hours', data: 0 },
     });
   });
@@ -162,7 +162,7 @@ describe('activityStatsToProps', () => {
   test('one data point', () => {
     expect(activityStatsToProps({ labels: ['foo'], value: 10 })).toEqual({
       topText: ['During ', moment().format('MMM YYYY')],
-      left: { label: 'Most popular activity was', data: ['foo'], limit: 2, placeholder: '...' },
+      left: { label: 'Most popular activity was', data: ['foo'], limit: 2, truncationString: '...' },
       right: { label: 'hours', data: 10 },
     });
   });
@@ -174,7 +174,7 @@ describe('activityStatsToProps', () => {
         label: 'Most popular activities were',
         data: ['foo', 'bar'],
         limit: 2,
-        placeholder: '...',
+        truncationString: '...',
       },
       right: {
         label: 'hours each',
@@ -189,7 +189,7 @@ describe('activityStatsToProps', () => {
         label: 'Most popular activities were',
         data: ['foo', 'bar', 'woo'],
         limit: 2,
-        placeholder: '...',
+        truncationString: '...',
       },
       right: {
         label: 'hours each',
@@ -204,7 +204,7 @@ describe('activityStatsToProps', () => {
         label: 'Most popular activities were',
         data: ['foo', 'bar', 'woo', 'war'],
         limit: 2,
-        placeholder: '...',
+        truncationString: '...',
       },
       right: {
         label: 'hours each',

--- a/dashboard-app/src/features/dashboard/Dashboard/__tests__/useDashboardStatistics.test.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/__tests__/useDashboardStatistics.test.ts
@@ -1,0 +1,214 @@
+import moment from 'moment';
+import {
+  timeStatsToProps,
+  volunteerStatsToProps,
+  activityStatsToProps
+} from '../useDashboardStatistics';
+
+
+describe('timeStatsToProps', () => {
+  test('no arguments', () => {
+    expect(timeStatsToProps()).toEqual({
+      topText: ['Over the past ', '12 months'],
+      left: { label: 'No data available', data: [] },
+      right: { label: 'hours', data: 0 },
+    });
+  });
+
+  test('zero data points', () => {
+    expect(timeStatsToProps({ labels: [], value: 0 })).toEqual({
+      topText: ['Over the past ', '12 months'],
+      left: { label: 'No data available', data: [], limit: 3, placeholder: '...' },
+      right: { label: 'hours', data: 0 },
+    });
+  });
+
+  test('one data point', () => {
+    expect(timeStatsToProps({ labels: ['foo'], value: 10 })).toEqual({
+      topText: ['Over the past ', '12 months'],
+      left: { label: 'Most volunteer days were in', data: ['foo'], limit: 3, placeholder: '...' },
+      right: { label: 'hours', data: 10 },
+    });
+  });
+
+  test('two data points', () => {
+    expect(timeStatsToProps({ labels: ['foo', 'bar'], value: 10 })).toEqual({
+      topText: ['Over the past ', '12 months'],
+      left: {
+        label: 'Most volunteer days were in',
+        data: ['foo', 'bar'],
+        limit: 3,
+        placeholder: '...',
+      },
+      right: { label: 'hours each', data: 10 },
+    });
+  });
+
+  test('three data points', () => {
+    expect(timeStatsToProps({ labels: ['foo', 'bar', 'woo'], value: 10 })).toEqual({
+      topText: ['Over the past ', '12 months'],
+      left: {
+        label: 'Most volunteer days were in',
+        data: ['foo', 'bar', 'woo'],
+        limit: 3,
+        placeholder: '...',
+      },
+      right: { label: 'hours each', data: 10 },
+    });
+  });
+
+  test('four data points', () => {
+    expect(timeStatsToProps({ labels: ['foo', 'bar', 'woo', 'war'], value: 10 })).toEqual({
+      topText: ['Over the past ', '12 months'],
+      left: {
+        label: 'Most volunteer days were in',
+        data: ['foo', 'bar', 'woo', 'war'],
+        limit: 3,
+        placeholder: '...',
+      },
+      right: { label: 'hours each', data: 10 },
+    });
+  });
+});
+
+describe('volunteerStatsToProps', () => {
+  test('no arguments', () => {
+    expect(volunteerStatsToProps()).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: { label: 'No data available', data: [] },
+      right: { label: '0 hours', data: [] },
+    });
+  });
+
+  test('zero data points', () => {
+    expect(volunteerStatsToProps({ labels: [], value: 0 })).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: { label: 'No data available', data: [] },
+      right: { label: '0 hours', data: [], limit: 3, placeholder: '...' },
+    });
+  });
+
+  test('one data point', () => {
+    expect(volunteerStatsToProps({ labels: ['foo'], value: 10 })).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: { label: 'Top volunteer', data: [] },
+      right: { label: '10 hours', data: ['foo'], limit: 3, placeholder: '...' },
+    });
+  });
+
+  test('two data points', () => {
+    expect(volunteerStatsToProps({ labels: ['foo', 'bar'], value: 10 })).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: {
+        label: 'Top volunteers',
+        data: [],
+      },
+      right: {
+        label: '10 hours each',
+        data: ['foo', 'bar'],
+        limit: 3,
+        placeholder: '...', },
+    });
+  });
+
+  test('three data points', () => {
+    expect(volunteerStatsToProps({ labels: ['foo', 'bar', 'woo'], value: 10 })).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: {
+        label: 'Top volunteers',
+        data: [],
+      },
+      right: {
+        label: '10 hours each',
+        data: ['foo', 'bar', 'woo'],
+        limit: 3,
+        placeholder: '...', },
+    });
+  });
+
+  test('four data points', () => {
+    expect(volunteerStatsToProps({ labels: ['foo', 'bar', 'woo', 'war'], value: 10 })).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: {
+        label: 'Top volunteers',
+        data: [],
+      },
+      right: {
+        label: '10 hours each',
+        data: ['foo', 'bar', 'woo', 'war'],
+        limit: 3,
+        placeholder: '...', },
+    });
+  });
+});
+
+describe('activityStatsToProps', () => {
+  test('no arguments', () => {
+    expect(activityStatsToProps()).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: { label: 'No data available', data: [] },
+      right: { label: 'hours', data: 0 },
+    });
+  });
+
+  test('zero data points', () => {
+    expect(activityStatsToProps({ labels: [], value: 0 })).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: { label: 'No data available', data: [], limit: 2, placeholder: '...' },
+      right: { label: 'hours', data: 0 },
+    });
+  });
+
+  test('one data point', () => {
+    expect(activityStatsToProps({ labels: ['foo'], value: 10 })).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: { label: 'Most popular activity was', data: ['foo'], limit: 2, placeholder: '...' },
+      right: { label: 'hours', data: 10 },
+    });
+  });
+
+  test('two data points', () => {
+    expect(activityStatsToProps({ labels: ['foo', 'bar'], value: 10 })).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: {
+        label: 'Most popular activities were',
+        data: ['foo', 'bar'],
+        limit: 2,
+        placeholder: '...',
+      },
+      right: {
+        label: 'hours each',
+        data: 10 },
+    });
+  });
+
+  test('three data points', () => {
+    expect(activityStatsToProps({ labels: ['foo', 'bar', 'woo'], value: 10 })).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: {
+        label: 'Most popular activities were',
+        data: ['foo', 'bar', 'woo'],
+        limit: 2,
+        placeholder: '...',
+      },
+      right: {
+        label: 'hours each',
+        data: 10 },
+    });
+  });
+
+  test('four data points', () => {
+    expect(activityStatsToProps({ labels: ['foo', 'bar', 'woo', 'war'], value: 10 })).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: {
+        label: 'Most popular activities were',
+        data: ['foo', 'bar', 'woo', 'war'],
+        limit: 2,
+        placeholder: '...',
+      },
+      right: {
+        label: 'hours each',
+        data: 10 },
+    });
+  });
+});

--- a/dashboard-app/src/features/dashboard/Dashboard/__tests__/util.test.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/__tests__/util.test.ts
@@ -93,5 +93,27 @@ describe('Dashboard statistics utilities', () => {
         value: 3,
       });
     });
+
+    test('non-date labels are sorted alphabetically', () => {
+      const logs = {
+        ['Toad']: [
+          { duration: { hours: 1, minutes: 50 } },
+          { duration: { hours: 1 } },
+        ],
+        ['Badger']: [
+          { duration: { hours: 2, minutes: 20 } },
+          { duration: { minutes: 30 } },
+        ],
+        ['Mole']: [
+          { duration: { hours: 1 } },
+          { duration: { minutes: 10 } },
+        ],
+      };
+
+      expect(findMostActive(logs)).toEqual({
+        labels: ['Badger', 'Toad'],
+        value: 3,
+      });
+    });
   });
 });

--- a/dashboard-app/src/features/dashboard/Dashboard/useDashboardStatistics.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/useDashboardStatistics.ts
@@ -4,6 +4,7 @@ import { innerJoin, collectBy } from 'twine-util/arrays';
 import { useBatchRequest } from '../../../lib/hooks';
 import { CommunityBusinesses } from '../../../lib/api';
 import { findMostActive } from './util';
+import { NumberTileProps, TextTileProps } from '../components/DataCard/types';
 import Months from '../../../lib/util/months';
 
 
@@ -109,7 +110,7 @@ export default () => {
 
 const getCurrentMonth = () => moment().format(Months.format.abreviated);
 
-export const activityStatsToProps = (pts?: EqualDataPoints) => {
+export const activityStatsToProps = (pts?: EqualDataPoints): NumberTileProps => {
   if (! pts) {
     return {
       topText: ['During ', getCurrentMonth()],
@@ -137,7 +138,7 @@ export const activityStatsToProps = (pts?: EqualDataPoints) => {
       label: leftLabel,
       data: pts.labels,
       limit: 2,
-      placeholder: '...',
+      truncationString: '...',
     },
     right: {
       label: rightLabel,
@@ -147,7 +148,7 @@ export const activityStatsToProps = (pts?: EqualDataPoints) => {
 };
 
 
-export const volunteerStatsToProps = (pts?: EqualDataPoints) => {
+export const volunteerStatsToProps = (pts?: EqualDataPoints): TextTileProps => {
   if (! pts) {
     return {
       topText: ['During ', getCurrentMonth()],
@@ -179,13 +180,13 @@ export const volunteerStatsToProps = (pts?: EqualDataPoints) => {
       label: rightLabel,
       data: pts.labels,
       limit: 3,
-      placeholder: '...',
+      truncationString: '...',
     },
   };
 };
 
 
-export const timeStatsToProps = (pts?: EqualDataPoints) => {
+export const timeStatsToProps = (pts?: EqualDataPoints): NumberTileProps => {
   if (! pts) {
     return {
       topText: ['Over the past ', '12 months'],
@@ -211,7 +212,7 @@ export const timeStatsToProps = (pts?: EqualDataPoints) => {
       label: leftLabel,
       data: pts.labels,
       limit: 3,
-      placeholder: '...',
+      truncationString: '...',
     },
     right: {
       label: rightLabel,

--- a/dashboard-app/src/features/dashboard/Dashboard/useDashboardStatistics.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/useDashboardStatistics.ts
@@ -12,6 +12,7 @@ export type EqualDataPoints = {
   value: number
 };
 
+
 export default () => {
   const oneYearAgo = moment().subtract(1, 'year').toDate();
   const now = moment().toDate();
@@ -135,6 +136,8 @@ export const activityStatsToProps = (pts?: EqualDataPoints) => {
     left: {
       label: leftLabel,
       data: pts.labels,
+      limit: 2,
+      placeholder: '...',
     },
     right: {
       label: rightLabel,
@@ -175,6 +178,8 @@ export const volunteerStatsToProps = (pts?: EqualDataPoints) => {
     right: {
       label: rightLabel,
       data: pts.labels,
+      limit: 3,
+      placeholder: '...',
     },
   };
 };
@@ -205,6 +210,8 @@ export const timeStatsToProps = (pts?: EqualDataPoints) => {
     left: {
       label: leftLabel,
       data: pts.labels,
+      limit: 3,
+      placeholder: '...',
     },
     right: {
       label: rightLabel,

--- a/dashboard-app/src/features/dashboard/Dashboard/useDashboardStatistics.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/useDashboardStatistics.ts
@@ -64,7 +64,7 @@ export default () => {
     // most active months (12 months)
     setTimeStats(
       findMostActive(
-        collectBy((log) => moment(log.startedAt).format(Months.format.verbose), fullLogs)
+        collectBy((log) => moment(log.startedAt).format(Months.format.abreviated), fullLogs)
       )
     );
 

--- a/dashboard-app/src/features/dashboard/Dashboard/useDashboardStatistics.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/useDashboardStatistics.ts
@@ -156,7 +156,7 @@ export const volunteerStatsToProps = (pts?: EqualDataPoints) => {
         data: [],
       },
       right: {
-        label: 'hours',
+        label: '0 hours',
         data: [],
       },
     };

--- a/dashboard-app/src/features/dashboard/Dashboard/util.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/util.ts
@@ -37,7 +37,14 @@ export const sumLogDurations = (a: Dictionary<VolunteerLog[]>) =>
 
 export const findMostActive = compose(
   ({ labels, value }) => ({
-    labels: labels.sort((a, b) => Months.diff(new Date(b), new Date(a))),
+    labels: labels.sort((a, b) => {
+      if (isNaN(new Date(`01 ${b}`).valueOf())) {
+        if (a < b) return -1;
+        if (a > b) return 1;
+        return 0;
+      }
+      return Months.diff(new Date(`01 ${b}`), new Date(`01 ${a}`));
+    }),
     value: Math.round(Duration.toHours(value)),
   }),
   collectMaxDurations,

--- a/dashboard-app/src/features/dashboard/Dashboard/util.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/util.ts
@@ -35,16 +35,19 @@ export const logsToDurations = compose(
 export const sumLogDurations = (a: Dictionary<VolunteerLog[]>) =>
   Objects.mapValues(logsToDurations, a);
 
+const sortByMonthOrAlpha = (xs: string[]) =>
+  xs.sort((a, b) => {
+    if (isNaN(new Date(`01 ${b}`).valueOf())) {
+      if (a < b) return -1;
+      if (a > b) return 1;
+      return 0;
+    }
+    return Months.diff(new Date(`01 ${b}`), new Date(`01 ${a}`));
+  });
+
 export const findMostActive = compose(
   ({ labels, value }) => ({
-    labels: labels.sort((a, b) => {
-      if (isNaN(new Date(`01 ${b}`).valueOf())) {
-        if (a < b) return -1;
-        if (a > b) return 1;
-        return 0;
-      }
-      return Months.diff(new Date(`01 ${b}`), new Date(`01 ${a}`));
-    }),
+    labels: sortByMonthOrAlpha(labels),
     value: Math.round(Duration.toHours(value)),
   }),
   collectMaxDurations,

--- a/dashboard-app/src/features/dashboard/Dashboard/util.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/util.ts
@@ -37,7 +37,7 @@ export const sumLogDurations = (a: Dictionary<VolunteerLog[]>) =>
 
 export const findMostActive = compose(
   ({ labels, value }) => ({
-    labels: labels.slice(0, 3).sort((a, b) => Months.diff(new Date(b), new Date(a))),
+    labels: labels.sort((a, b) => Months.diff(new Date(b), new Date(a))),
     value: Math.round(Duration.toHours(value)),
   }),
   collectMaxDurations,

--- a/dashboard-app/src/features/dashboard/components/DataCard/index.tsx
+++ b/dashboard-app/src/features/dashboard/components/DataCard/index.tsx
@@ -74,18 +74,18 @@ const alternateBold = (xs: string[], offset = 0) => (
   </Paragraph>
 );
 
-const truncateWords = (xs: string[], limit: number, placeholder: string) =>
-  String.listify(Arrays.truncate(xs, limit, placeholder), { and: limit >= xs.length });
+const truncateWords = (xs: string[], limit: number, truncationString: string) =>
+  String.listify(Arrays.truncate(xs, limit, truncationString), { and: limit >= xs.length });
 
 /*
  * Components
  */
 const LeftContainer: FunctionComponent<TileDataPoint<string[]>> = (props) => {
-  const { limit = Infinity, data, placeholder = '' } = props;
+  const { limit = Infinity, data, truncationString = '' } = props;
   return (
     <MiddleTopLeftContainer>
       <Paragraph>{props.label}</Paragraph>
-      {alternateBold(truncateWords(data, limit, placeholder))}
+      {alternateBold(truncateWords(data, limit, truncationString))}
     </MiddleTopLeftContainer>
   );
 };
@@ -104,8 +104,8 @@ const NumberRightContainer: FunctionComponent<NumberTileProps['right']> = (props
 };
 
 const TextRightContainer: FunctionComponent<TextTileProps['right']> = (props) => {
-  const { limit = Infinity, data, placeholder = '' } = props;
-  const items = Arrays.truncate(data, limit, placeholder);
+  const { limit = Infinity, data, truncationString = '' } = props;
+  const items = Arrays.truncate(data, limit, truncationString);
   return (
     <>
       <TextMiddleTopRightContainer>

--- a/dashboard-app/src/features/dashboard/components/DataCard/index.tsx
+++ b/dashboard-app/src/features/dashboard/components/DataCard/index.tsx
@@ -1,9 +1,10 @@
 import React, { FunctionComponent } from 'react';
 import styled from 'styled-components';
-import { String } from 'twine-util';
+import { String, Arrays } from 'twine-util';
 import { Paragraph, Bold } from '../../../../lib/ui/components/Typography';
 import { ColoursEnum, Fonts } from '../../../../lib/ui/design_system';
 import { TextTileProps, NumberTileProps, TileDataPoint } from './types';
+
 
 /*
  * Styles
@@ -61,23 +62,30 @@ const BottomContainer = styled.div`
 /*
  * Helpers
  */
-const alternateBold = (xs: string[]) => (
-  <Paragraph>{xs.map((x, i) => {
-    return i % 2 > 0
-      ? (<Bold key={`bold_${x}`}>{x}</Bold>)
-      : x;
-  })}</Paragraph>
+const alternateBold = (xs: string[], offset = 0) => (
+  <Paragraph>
+    {
+      xs.map((x, i) =>
+        (i + offset) % 2 === 0
+          ? <Bold key={`bold_${x}`}>{x}</Bold>
+          : x
+      )
+    }
+  </Paragraph>
 );
+
+const truncateWords = (xs: string[], limit: number, placeholder: string) =>
+  String.listify(Arrays.truncate(xs, limit, placeholder), { and: limit >= xs.length });
 
 /*
  * Components
  */
 const LeftContainer: FunctionComponent<TileDataPoint<string[]>> = (props) => {
-  const dataSentence = ['', ...String.listify(props.data)];
+  const { limit = Infinity, data, placeholder = '' } = props;
   return (
     <MiddleTopLeftContainer>
       <Paragraph>{props.label}</Paragraph>
-      {alternateBold(dataSentence)}
+      {alternateBold(truncateWords(data, limit, placeholder))}
     </MiddleTopLeftContainer>
   );
 };
@@ -96,10 +104,12 @@ const NumberRightContainer: FunctionComponent<NumberTileProps['right']> = (props
 };
 
 const TextRightContainer: FunctionComponent<TextTileProps['right']> = (props) => {
+  const { limit = Infinity, data, placeholder = '' } = props;
+  const items = Arrays.truncate(data, limit, placeholder);
   return (
     <>
       <TextMiddleTopRightContainer>
-        {props.data.map((x) => (<Paragraph key={`right_${x}`}><Bold>{x}</Bold></Paragraph>))}
+        {items.map((x) => <Paragraph key={`right_${x}`}><Bold>{x}</Bold></Paragraph>)}
       </TextMiddleTopRightContainer>
       <MiddleBottomRightContainer>
         <Paragraph>{props.label}</Paragraph>
@@ -110,22 +120,23 @@ const TextRightContainer: FunctionComponent<TextTileProps['right']> = (props) =>
 
 const DataCard: FunctionComponent<NumberTileProps | TextTileProps> = (props) => {
   const { topText, left, bottomText, children } = props;
-  return(
-  <Grid>
-    <TopTextContainer>
-      {alternateBold(topText)}
-    </TopTextContainer>
-    <LeftContainer {...left}/>
-    {children}
-    <BottomContainer>
-      {bottomText && alternateBold(bottomText)}
-    </BottomContainer>
-  </Grid>);
+  return (
+    <Grid>
+      <TopTextContainer>
+        {alternateBold(topText, 1)}
+      </TopTextContainer>
+      <LeftContainer {...left}/>
+      {children}
+      <BottomContainer>
+        {bottomText && alternateBold(bottomText, 1)}
+      </BottomContainer>
+    </Grid>
+  );
 };
 
 export const NumberDataCard: FunctionComponent<NumberTileProps> = (props) => {
   const { right } = props;
-  return(
+  return (
     <DataCard {...props} >
       <NumberRightContainer {...right}/>
     </DataCard>
@@ -134,7 +145,7 @@ export const NumberDataCard: FunctionComponent<NumberTileProps> = (props) => {
 
 export const TextDataCard: FunctionComponent<TextTileProps> = (props) => {
   const { right } = props;
-  return(
+  return (
     <DataCard {...props} >
       <TextRightContainer {...right}/>
     </DataCard>

--- a/dashboard-app/src/features/dashboard/components/DataCard/types.ts
+++ b/dashboard-app/src/features/dashboard/components/DataCard/types.ts
@@ -6,6 +6,8 @@
 export type TileDataPoint<T> = {
   label: string
   data: T
+  limit?: number
+  placeholder?: string
 };
 
 export type NumberTileProps = {

--- a/dashboard-app/src/features/dashboard/components/DataCard/types.ts
+++ b/dashboard-app/src/features/dashboard/components/DataCard/types.ts
@@ -7,7 +7,7 @@ export type TileDataPoint<T> = {
   label: string
   data: T
   limit?: number
-  placeholder?: string
+  truncationString?: string
 };
 
 export type NumberTileProps = {

--- a/lib/twine-util/__tests__/arrays.test.ts
+++ b/lib/twine-util/__tests__/arrays.test.ts
@@ -1,4 +1,4 @@
-import { sort, innerJoin, collectBy, Order } from '../arrays';
+import { sort, innerJoin, collectBy, truncate, Order } from '../arrays';
 
 
 describe('Arrays', () => {
@@ -191,5 +191,17 @@ describe('Arrays', () => {
           even: [2, 4],
         });
     });
+  });
+
+  describe('truncate', () => {
+    test('array below limit', () => {
+      const xs = ['1', '2', '3'];
+      expect(truncate(xs, 10, '...')).toEqual(xs);
+    });
+
+    test('array above limit', () => {
+      const xs = ['1', '2', '3'];
+      expect(truncate(xs, 2, '...')).toEqual(['1', '2', '...']);
+    })
   });
 });

--- a/lib/twine-util/__tests__/string.test.ts
+++ b/lib/twine-util/__tests__/string.test.ts
@@ -35,24 +35,44 @@ describe('String', () => {
     test('returns empty array when empty', () => {
       expect(listify([])).toEqual([]);
     });
+
     test('returns array when it contains 1 element', () => {
       expect(listify(['hi'])).toEqual(['hi']);
     });
+
     test('adds "and" for 2 elements', () => {
       const sentence = listify(['chocolate', 'bananas']);
       const readableSentence = readableListify(['chocolate', 'bananas']);
       expect(sentence).toEqual(['chocolate', ' and ', 'bananas']);
       expect(readableSentence).toBe('chocolate and bananas');
     });
+
     test('adds "," & "and" for 3 elements', () => {
       const sentence = listify(['chocolate', 'bananas', 'peanut butter']);
       const readableSentence = readableListify(['chocolate', 'bananas', 'peanut butter']);
       expect(sentence).toEqual(['chocolate', ', ', 'bananas', ' and ', 'peanut butter']);
       expect(readableSentence).toBe('chocolate, bananas and peanut butter');
     });
+
     test('adds multiple "," & "and" for 4 elements', () => {
       const sentence = listify(['chocolate', 'bananas', 'peanut butter', 'ice cream']);
       const readableSentence = readableListify(['chocolate', 'bananas', 'peanut butter', 'ice cream']);
+      expect(sentence)
+        .toEqual(['chocolate', ', ', 'bananas', ', ', 'peanut butter', ' and ', 'ice cream']);
+      expect(readableSentence).toBe('chocolate, bananas, peanut butter and ice cream');
+    });
+
+    test('adds only commas if "and" option is present and false', () => {
+      const sentence = listify(['chocolate', 'bananas', 'peanut butter', 'ice cream'], { and: false });
+      const readableSentence = readableListify(['chocolate', 'bananas', 'peanut butter', 'ice cream'], { and: false });
+      expect(sentence)
+        .toEqual(['chocolate', ', ', 'bananas', ', ', 'peanut butter', ', ', 'ice cream']);
+      expect(readableSentence).toBe('chocolate, bananas, peanut butter, ice cream');
+    });
+
+    test('adds "," and "and" normally if "and" option is present and true', () => {
+      const sentence = listify(['chocolate', 'bananas', 'peanut butter', 'ice cream'], { and: true });
+      const readableSentence = readableListify(['chocolate', 'bananas', 'peanut butter', 'ice cream'], { and: true });
       expect(sentence)
         .toEqual(['chocolate', ', ', 'bananas', ', ', 'peanut butter', ' and ', 'ice cream']);
       expect(readableSentence).toBe('chocolate, bananas, peanut butter and ice cream');

--- a/lib/twine-util/arrays.ts
+++ b/lib/twine-util/arrays.ts
@@ -50,3 +50,8 @@ export const collectBy = <T>(fn: (a: T) => string, xs: T[]) =>
     assoc(fn(x), acc.hasOwnProperty(fn(x)) ? acc[fn(x)].concat(x) : [x], acc),
     {} as Dictionary<T[]>
   );
+
+export const truncate = <T>(xs: T[], limit: number, placeholder: T) =>
+  limit < xs.length
+    ? xs.slice(0, limit).concat(placeholder)
+    : xs;

--- a/lib/twine-util/string.ts
+++ b/lib/twine-util/string.ts
@@ -13,7 +13,11 @@ export const onlynl = (ss: TemplateStringsArray, ...placeholders: any[]) =>
     .replace(/[\ \t][\ \t]+/g, '');
 
 
-export const listify = (xs: string[]) => {
+export const listify = (xs: string[], opts: { and?: boolean } = { and: true }) => {
+  if (!opts.and) {
+    return intersperse(', ', xs);
+  }
+
   switch (xs.length) {
     case 0:
     case 1:
@@ -29,5 +33,5 @@ export const listify = (xs: string[]) => {
 };
 
 
-export const readableListify = (xs: string[]) =>
-  listify(xs).join('');
+export const readableListify = (xs: string[], opts?: { and: boolean }) =>
+  listify(xs, opts).join('');


### PR DESCRIPTION
Fixes #236

Moved the truncation logic inside `DataCard` (mediated by props) because it handles the bolding internally. Alternatively we could make `DataCard` accept render props and move the logic outside, but this seems more complicated than necessary. The other alternative is to add more of the application logic inside the `DataCard` but this seems like a bad idea if we're trying to keep it as dumb as possible.

### Changes
- Add tests on `*StatsToProps` functions
- Modify `String.listify` to accept flag telling it not to insert `"and"` in the list -- defaults to the pre-existing behaviour
- Add another util to handle truncation
- `alternateBold` accepts an `offset` argument to avoid having to prepend an empty string to the argument sometimes
- Statistics functions now pass _all_ top values to the `DataCard` component, not just the first three, and the `DataCard` does the truncation.

### Testing Requirements
QA already passed

### Release Requirements
Can be released as soon as it is merged.

### Manual Deployment
- [ ] Dashboard App