### PR TITLE
🔐 modify external strategy to allow CB access

### DIFF
--- a/api/bin/api_token.ts
+++ b/api/bin/api_token.ts
@@ -1,0 +1,38 @@
+/*
+ * Command line utility for creating an API token
+ */
+import * as parse from 'minimist';
+import * as Knex from 'knex';
+import { getConfig } from '../config';
+import { ApiTokens } from '../src/models';
+
+
+process.on('unhandledRejection', (err) => { throw err; });
+
+const { cb, scope } = parse(process.argv.slice(2));
+
+if (!cb || !scope) {
+  throw new Error('Missing arguments');
+}
+
+(async () => {
+  const { knex: config, env } = getConfig(process.env.NODE_ENV);
+  const client = Knex(config);
+
+  try {
+    const tkn = await ApiTokens.add(client, ApiTokens.create(cb, scope));
+
+    console.log(`
+      API token added to ${env} database:
+        ID: ${tkn.id}
+        Name: ${tkn.name}
+        Access: ${tkn.access}
+    `);
+
+  } catch (error) {
+    console.log('Something went wrong!');
+    console.log(error);
+  }
+
+  await client.destroy();
+})();

--- a/api/bin/api_token.ts
+++ b/api/bin/api_token.ts
@@ -6,7 +6,7 @@
  *
  * Flags:
  *  cb: Name of the CB for which to create the API token
- *  scope: What scope to give the token (corresponds to api_token_access column)
+ *  scope: What scope to give the token (see /docs/permissions#api-token-permissions)
  *
  * Note: Including the argument separator `--` before any of the flags is important.
  *   Without it, the argument parsing will not work.
@@ -14,7 +14,7 @@
 import * as parse from 'minimist';
 import * as Knex from 'knex';
 import { getConfig } from '../config';
-import { ApiTokens } from '../src/models';
+import { ApiTokens, CommunityBusinesses } from '../src/models';
 
 
 process.on('unhandledRejection', (err) => { throw err; });
@@ -30,6 +30,12 @@ if (!cb || !scope) {
   const client = Knex(config);
 
   try {
+    const exists = await CommunityBusinesses.exists(client, { where: { name: cb } });
+
+    if (!exists) {
+      throw new Error(`No community business by the name ${cb} was found`);
+    }
+
     const tkn = await ApiTokens.add(client, ApiTokens.create(cb, scope));
 
     console.log(`

--- a/api/bin/api_token.ts
+++ b/api/bin/api_token.ts
@@ -1,5 +1,15 @@
 /*
  * Command line utility for creating an API token
+ *
+ * Usage:
+ *  npm run exec ./bin/api_token.ts -- --cb=CB_NAME --scope=SCOPE
+ *
+ * Flags:
+ *  cb: Name of the CB for which to create the API token
+ *  scope: What scope to give the token (corresponds to api_token_access column)
+ *
+ * Note: Including the argument separator `--` before any of the flags is important.
+ *   Without it, the argument parsing will not work.
  */
 import * as parse from 'minimist';
 import * as Knex from 'knex';

--- a/api/database/data/testing/test_09_api_token.seed.ts
+++ b/api/database/data/testing/test_09_api_token.seed.ts
@@ -1,4 +1,10 @@
 import * as Knex from 'knex';
+import { hashSync } from 'bcrypt';
+
+
+const apertureScienceToken = 'aperture-token';
+const blackMesaToken = 'blackmesa-token';
+
 
 exports.seed = (knex: Knex) =>
   knex('api_token')
@@ -10,5 +16,13 @@ exports.seed = (knex: Knex) =>
       { api_token_name: 'testaccount2',
         api_token_access: 'frontline',
         api_token: '$2a$12$ljINX3VanQvCEycBOqvfw.UDMd4DXiRwU23Z9Vw6IVu3TDOKbrXuG',
+      },
+      { api_token_name: 'Aperture Science',
+        api_token_access: 'api:visitor:read',
+        api_token: hashSync(apertureScienceToken, 1),
+      },
+      { api_token_name: 'Black Mesa Research',
+        api_token_access: 'api:visitor:read',
+        api_token: hashSync(blackMesaToken, 1),
       },
     ]);

--- a/api/docs/README.md
+++ b/api/docs/README.md
@@ -12,3 +12,4 @@
 1. [Stack](./stack.md)
 1. [Deployment](./deployment.md)
 1. [Reporting](./reporting.md)
+1. [Authentication](./authentication.md)

--- a/api/docs/authentication.md
+++ b/api/docs/authentication.md
@@ -1,0 +1,23 @@
+# Authentication
+
+There are three ways to authenticate with the API: a cookie-based method, and two token-based methods.
+
+## Summary
+### Cookie Authentication
+This is a server-side session based method, using the `standard` authentication strategy, and is intended for all users interacting normally with client web-apps. Session IDs are stored in a cookie passed to the client, and session records are stored in a session cache on the backend.
+
+### Token Authentication
+This is also a server-side session based method, using the `standard` authentication strategy, and is intended for users of the _Volunteer native app_. This functions the same way as the cookie-based method, but the session ID is sent in the `Authorization` header instead of in a cookie (since cookies can be problematic on Cordova/Ionic-v1 apps).
+
+### Bearer Token Authentication
+This is a token-based method, using the `external` authentication strategy, and is intended for registered users of the platform who wish to access their own data programmatically. It is differentiated from the previous token-based method because it uses the "bearer token" format (i.e. `Authorization: Bearer <TOKEN>`).
+
+## User Instructions
+
+### Bearer Token Authentication
+You must first get in contact in order to request an API token from Twine. Once you have received your token, you may use it as a bearer token in HTTP `GET` requests to endpoints that are publicly exposed, a [list of which can be found here](./public_api.md)
+
+For example:
+```
+$ curl -H "Authorization: Bearer <TOKEN>" https://api.twine-together.com/v1/community-businesses/me/visitors
+```

--- a/api/docs/permissions.md
+++ b/api/docs/permissions.md
@@ -1,5 +1,7 @@
 # Permissions
-## Resources and their ownership
+
+## User Permissions
+### Resources and their ownership
 | Resource | Owner | Description |
 |----------|-------|-------------|
 | `organisations_details` | 🏢 Organisation | Core organisation details |
@@ -19,12 +21,20 @@
 * In the application, the "Organisation" is represented by `CB_ADMIN` users.
 * The resource `users_details_anonymised` is not currently used but may be needed for funding bodies to access anonymised user data.
 
-## Permission flags
+### Permission flags
 * `*-children` - data of all child catagories
 * `*-parent` - data of all parent catagories
 * `*-own` - data directly owned by user
 * `*-sibling` - data owned by a sibling (same level) user
 
+## API Token Permissions
+API tokens (currently) use a different set of permissions. This is simply to make the initial implementation simple. In future, as third-party access to the API is widened, it may be beneficial for API tokens to use the same permission set as regular users.
+
+For now the only permission is:
+```
+api:visitor:read
+```
+Which is intended to allow read access to all resources related to the visitor app.
 
 ## References
 

--- a/api/docs/public_api.md
+++ b/api/docs/public_api.md
@@ -1,0 +1,129 @@
+# Public API
+
+Some parts of the API are publicly exposed and accessible to registered users who have an API access token. See the [authentication](./authentication) section for more information on this.
+
+The endpoints of the API that are made public are documented below.
+
+## Contents
+- [Common query parameters](#common-query-parameters)
+- [Endpoints](#endpoints)
+  - [GET /v1/community-businesses/me](#get-v1community-businessesme)
+  - [GET /v1/community-businesses/me/visitors](#get-v1community-businessesmevisitors)
+  - [GET /v1/community-businesses/me/visitors/:id](#get-v1community-businessesmevisitorsid)
+  - [GET /v1/community-businesses/me/feedback](#get-v1community-businessesmefeedback)
+  - [GET /v1/community-businesses/me/feedback/aggregates](#get-v1community-businessesmefeedbackaggregates)
+  - [GET /v1/community-businesses/me/visit-activities](#get-v1community-businessesmevisit-activities)
+  - [GET /v1/community-businesses/me/visit-logs](#get-v1community-businessesmevisit-logs)
+  - [GET /v1/community-businesses/me/visit-logs/aggregates](#get-v1community-businessesmevisit-logsaggregates)
+
+
+## Common query parameters
+The API supports objects and arrays in query strings, encoded and parsed by the [qs](https://npmjs.com/package/qs) module (e.g. `?array[0]=foo&array[1]=bar` is parsed to `array=['foo', 'bar']`). See the qs module's documentation for more examples.
+x
+Where specified, the following query parameters all have the same meaning:
+
+### `fields`
+- Array of strings (field names)
+
+Specify which fields of the response payload to return.
+
+Example: `?fields[]=id&fields[]=name`
+
+### `limit`
+- Integer
+
+Specify the maximum number of results to return
+
+Example: `?limit=10`
+
+### `offset`
+- Integer
+
+Specify the offset from the first record when returning results (used for pagination)
+
+Example: `?offset:100`
+
+### `sort`
+- String (field name)
+
+Specify which field of the response payload to sort results by
+
+Example: `?sort=birthYear`
+
+### `order`
+- "asc" or "desc"
+
+Specify the order of the sort
+
+Example: `?sort=birthYear&order=asc`
+
+## Endpoints
+### GET /v1/community-businesses/me
+Query parameters:
+- [`fields`](#fields)
+
+### GET /v1/community-businesses/me/visitors
+Query parameters:
+- [`fields`](#fields)
+- [`limit`](#limit)
+- [`offset`](#offset)
+- [`sort`](#sort)
+- [`order`](#order)
+- `visits`: boolean -- Should include list of visits with each user record
+- `filter`: -- inclusive filter on list of results
+  - `age`: [integer, integer] -- age limits, min to max
+  - `gender`: male | female | prefer not to say
+  - `name`: string -- full name filter (no partial match or fuzzy search)
+  - `email`: string
+  - `postCode`: string
+  - `phoneNumber`: string
+  - `visitActivity`: string -- filter on visit activity name
+
+### GET /v1/community-businesses/me/visitors/:id
+Query parameters:
+- `visits`: boolean -- Should include list of visits with each user record
+
+### GET /v1/community-businesses/me/feedback
+Query parameters:
+- [`limit`](#limit)
+- [`offset`](#offset)
+- `since`: ISO-86001 date string
+- `until`: ISO-86001 date string
+
+### GET /v1/community-businesses/me/feedback/aggregates
+Query parameters:
+- `since`: ISO Date string
+- `until`: ISO Date string
+
+### GET /v1/community-businesses/me/visit-activities
+Query parameters:
+- [`fields`](#fields)
+- [`limit`](#limit)
+- [`offset`](#offset)
+- [`sort`](#sort)
+- [`order`](#order)
+- `day`: "today" | lower-case weekday -- day for which to return activities
+
+### GET /v1/community-businesses/me/visit-logs
+Query parameters:
+- [`fields`](#fields)
+- [`limit`](#limit)
+- [`offset`](#offset)
+- [`sort`](#sort)
+- [`order`](#order)
+- `filter`: -- inclusive filter on list of results
+  - `age`: [integer, integer] -- age limits, min to max
+  - `visitActivity`: string -- filter on visit activity name
+  - `gender`: male | female | prefer not to say
+
+### GET /v1/community-businesses/me/visit-logs/aggregates
+Query parameters:
+- `fields`: Array of any of `gender`, `age`, `visitActivity`, or `lastWeek`
+- [`limit`](#limit)
+- [`offset`](#offset)
+- [`sort`](#sort)
+- [`order`](#order)
+- `filter`: -- inclusive filter on list of results
+  - `age`: [integer, integer] -- age limits, min to max
+  - `visitActivity`: string -- filter on visit activity name
+  - `gender`: male | female | prefer not to say

--- a/api/src/api/v1/auth.ts
+++ b/api/src/api/v1/auth.ts
@@ -17,7 +17,7 @@ export const getCredentialsFromRequest = (request: Hapi.Request) => {
       return externalStrategy.ExternalCredentials.fromRequest(request);
 
     default:
-      throw new Error('');
+      throw new Error(`Unrecognised strategy: ${request.auth.strategy}`);
   }
 };
 

--- a/api/src/api/v1/auth.ts
+++ b/api/src/api/v1/auth.ts
@@ -11,7 +11,7 @@ const AuthBearer = require('hapi-auth-bearer-token');
 export const getCredentialsFromRequest = (request: Hapi.Request) => {
   switch (request.auth.strategy) {
     case standardStrategy.name:
-      return standardStrategy.StandardCredentials.fromRequest(request);
+      return standardStrategy.Credentials.fromRequest(request);
 
     case externalStrategy.name:
       return externalStrategy.ExternalCredentials.fromRequest(request);

--- a/api/src/api/v1/auth.ts
+++ b/api/src/api/v1/auth.ts
@@ -8,6 +8,20 @@ import * as externalStrategy from '../../auth/strategies/external';
 const AuthBearer = require('hapi-auth-bearer-token');
 
 
+export const getCredentialsFromRequest = (request: Hapi.Request) => {
+  switch (request.auth.strategy) {
+    case standardStrategy.name:
+      return standardStrategy.StandardCredentials.fromRequest(request);
+
+    case externalStrategy.name:
+      return externalStrategy.ExternalCredentials.fromRequest(request);
+
+    default:
+      throw new Error('');
+  }
+};
+
+
 export default async (server: Hapi.Server) => {
   const { config: { auth: { schema } } } = server.app;
 

--- a/api/src/api/v1/community_businesses/feedback.ts
+++ b/api/src/api/v1/community_businesses/feedback.ts
@@ -15,9 +15,9 @@ export default [
     options: {
       description: 'Retrieve information about own community business',
       auth: {
-        strategy: 'standard',
+        strategies: ['standard', 'external'],
         access: {
-          scope: ['organisations_feedback-own:read'],
+          scope: ['organisations_feedback-own:read', 'api:visitor:read'],
         },
       },
       validate: {
@@ -115,9 +115,9 @@ export default [
     options: {
       description: 'Retrieve information about own community business',
       auth: {
-        strategy: 'standard',
+        strategies: ['standard', 'external'],
         access: {
-          scope: ['organisations_feedback-own:read'],
+          scope: ['organisations_feedback-own:read', 'api:visitor:read'],
         },
       },
       validate: { query: { since, until, ...query } },

--- a/api/src/api/v1/community_businesses/get.ts
+++ b/api/src/api/v1/community_businesses/get.ts
@@ -48,9 +48,13 @@ export default [
     options: {
       description: 'Retrieve information about users own community business',
       auth: {
-        strategy: 'standard',
+        strategies: ['standard', 'external'],
         access: {
-          scope: ['organisations_details-own:read', 'organisations_details-parent:read'],
+          scope: [
+            'organisations_details-own:read',
+            'organisations_details-parent:read',
+            'api:visitor:read',
+          ],
         },
       },
       validate: {

--- a/api/src/api/v1/community_businesses/visit_activities.ts
+++ b/api/src/api/v1/community_businesses/visit_activities.ts
@@ -31,9 +31,9 @@ export default [
     options: {
       description: 'Retrieve all visit activities for a community business',
       auth: {
-        strategy: 'standard',
+        strategies: ['standard', 'external'],
         access: {
-          scope: ['visit_activities-own:read'],
+          scope: ['visit_activities-own:read', 'api:visitor:read'],
         },
       },
       pre: [

--- a/api/src/api/v1/community_businesses/visit_logs.ts
+++ b/api/src/api/v1/community_businesses/visit_logs.ts
@@ -95,9 +95,9 @@ const routes: Hapi.ServerRoute[] = [
     options: {
       description: 'Retrieve a list of visit logs for your community business',
       auth: {
-        strategy: 'standard',
+        strategies: ['standard', 'external'],
         access: {
-          scope: ['visit_logs-child:read'],
+          scope: ['visit_logs-child:read', 'api:visitor:read'],
         },
       },
       validate: {

--- a/api/src/api/v1/community_businesses/visit_logs_aggregates.ts
+++ b/api/src/api/v1/community_businesses/visit_logs_aggregates.ts
@@ -14,9 +14,9 @@ const routes: Hapi.ServerRoute[] = [
     options: {
       description: 'Retrieve a list of aggregated visit data for your community businesses',
       auth: {
-        strategy: 'standard',
+        strategies: ['standard', 'external'],
         access: {
-          scope: ['visit_logs-child:read'],
+          scope: ['visit_logs-child:read', 'api:visitor:read'],
         },
       },
       validate: {

--- a/api/src/api/v1/community_businesses/visitors/get.ts
+++ b/api/src/api/v1/community_businesses/visitors/get.ts
@@ -103,9 +103,9 @@ const routes: Hapi.ServerRoute[] = [
     options: {
       description: 'Retreive list of all visitors from an organisation',
       auth: {
-        strategy: 'standard',
+        strategies: ['standard', 'external'],
         access: {
-          scope: ['user_details-child:read'],
+          scope: ['user_details-child:read', 'api:visitor:read'],
         },
       },
       validate: {

--- a/api/src/api/v1/community_businesses/visitors/get.ts
+++ b/api/src/api/v1/community_businesses/visitors/get.ts
@@ -25,9 +25,9 @@ const routes: Hapi.ServerRoute[] = [
     options: {
       description: 'Retreive list of all visitors from an organisation',
       auth: {
-        strategy: 'standard',
+        strategies: ['standard', 'external'],
         access: {
-          scope: ['user_details-child:read'],
+          scope: ['user_details-child:read', 'api:visitor:read'],
         },
       },
       validate: {

--- a/api/src/api/v1/hooks/on_pre_response.ts
+++ b/api/src/api/v1/hooks/on_pre_response.ts
@@ -32,7 +32,7 @@ export default async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
 
   if ((<Boom<any>> request.response).isBoom) {
     const err = <BoomWithValidation> request.response;
-    if (env !== Environment.TESTING) console.log(err);
+    console.log(err);
     return h.response(formatBoom(err)).code(err.output.statusCode);
   } else {
     return h.continue;

--- a/api/src/api/v1/hooks/on_pre_response.ts
+++ b/api/src/api/v1/hooks/on_pre_response.ts
@@ -32,7 +32,7 @@ export default async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
 
   if ((<Boom<any>> request.response).isBoom) {
     const err = <BoomWithValidation> request.response;
-    console.log(err);
+    if (env !== Environment.TESTING) console.log(err);
     return h.response(formatBoom(err)).code(err.output.statusCode);
   } else {
     return h.continue;

--- a/api/src/api/v1/prerequisites/__tests__/get_community_business.test.integration.ts
+++ b/api/src/api/v1/prerequisites/__tests__/get_community_business.test.integration.ts
@@ -116,7 +116,7 @@ describe('Prerequisites :: getCommunityBusiness', () => {
     const res = await server.inject(injectCfg({
       method: 'GET',
       url: '/foo/me',
-      credentials: <any> ExternalCredentials.get(knex, 'aperture-token'),
+      credentials: await ExternalCredentials.get(knex, 'aperture-token'),
       strategy: ExtName,
     }));
 

--- a/api/src/api/v1/prerequisites/__tests__/get_community_business.test.integration.ts
+++ b/api/src/api/v1/prerequisites/__tests__/get_community_business.test.integration.ts
@@ -5,7 +5,7 @@ import { getConfig } from '../../../../../config';
 import pre from '../get_community_business';
 import { CommunityBusinesses, Organisations, CbAdmins, Users } from '../../../../models';
 import { injectCfg } from '../../../../../tests/utils/inject';
-import { ExternalCredentials } from '../../../../auth/strategies/external';
+import { ExternalCredentials, name as ExtName } from '../../../../auth/strategies/external';
 
 
 describe('Prerequisites :: getCommunityBusiness', () => {
@@ -117,7 +117,7 @@ describe('Prerequisites :: getCommunityBusiness', () => {
       method: 'GET',
       url: '/foo/me',
       credentials: <any> ExternalCredentials.get(knex, 'aperture-token'),
-      strategy: 'external',
+      strategy: ExtName,
     }));
 
     expect(res.statusCode).toBe(200);

--- a/api/src/api/v1/prerequisites/__tests__/get_community_business.test.integration.ts
+++ b/api/src/api/v1/prerequisites/__tests__/get_community_business.test.integration.ts
@@ -5,6 +5,7 @@ import { getConfig } from '../../../../../config';
 import pre from '../get_community_business';
 import { CommunityBusinesses, Organisations, CbAdmins, Users } from '../../../../models';
 import { injectCfg } from '../../../../../tests/utils/inject';
+import { ExternalCredentials } from '../../../../auth/strategies/external';
 
 
 describe('Prerequisites :: getCommunityBusiness', () => {
@@ -107,5 +108,19 @@ describe('Prerequisites :: getCommunityBusiness', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.result).toEqual(communityBusiness);
+  });
+
+  test('can be accessed by external auth strategy', async () => {
+    const cb = await CommunityBusinesses.getOne(knex, { where: { id: 1 } });
+
+    const res = await server.inject(injectCfg({
+      method: 'GET',
+      url: '/foo/me',
+      credentials: <any> ExternalCredentials.get(knex, 'aperture-token'),
+      strategy: 'external',
+    }));
+
+    expect(res.statusCode).toBe(200);
+    expect(res.result).toEqual(cb);
   });
 });

--- a/api/src/api/v1/prerequisites/get_community_business.ts
+++ b/api/src/api/v1/prerequisites/get_community_business.ts
@@ -11,13 +11,13 @@ import * as Boom from '@hapi/boom';
 import { isNil } from 'ramda';
 import { CommunityBusinesses } from '../../../models';
 import { GetCommunityBusinessRequest } from '../types';
-import { Credentials as StandardCredentials } from '../../../auth/strategies/standard';
+import { getCredentialsFromRequest } from '../auth';
 
 
 export const is360GivingId = (s: string) => isNaN(parseInt(s, 10));
 const getCbFromCredentials = async (request: GetCommunityBusinessRequest) => {
   const knex = request.server.app.knex;
-  const id = StandardCredentials.fromRequest(request).organisation.id;
+  const id = getCredentialsFromRequest(request).organisation.id;
   return CommunityBusinesses.getOne(knex, { where: { id } });
 };
 

--- a/api/src/api/v1/prerequisites/get_community_business.ts
+++ b/api/src/api/v1/prerequisites/get_community_business.ts
@@ -27,7 +27,7 @@ export default async (request: GetCommunityBusinessRequest, h: Hapi.ResponseTool
   const communityBusiness =
     (id === 'me' || isNil(id))
       ? await getCbFromCredentials(request)
-      : (is360GivingId(id))
+      : is360GivingId(id)
         ? await CommunityBusinesses.getOne(knex, { where: { _360GivingId: id } })
         : await CommunityBusinesses.getOne(knex, { where: { id: Number(id) } });
 

--- a/api/src/api/v1/prerequisites/get_organisation.ts
+++ b/api/src/api/v1/prerequisites/get_organisation.ts
@@ -10,7 +10,7 @@ import * as Hapi from '@hapi/hapi';
 import * as Boom from '@hapi/boom';
 import { Organisations } from '../../../models';
 import { GetCommunityBusinessRequest } from '../types';
-import { Credentials as StandardCredentials } from '../../../auth/strategies/standard';
+import { getCredentialsFromRequest } from '../auth';
 
 
 const is360GivingId = (s: string) => isNaN(parseInt(s, 10));
@@ -20,7 +20,7 @@ export default async (request: GetCommunityBusinessRequest, h: Hapi.ResponseTool
 
   const organisation =
     (id === 'me')
-      ? StandardCredentials.fromRequest(request).organisation
+      ? getCredentialsFromRequest(request).organisation
       : (is360GivingId(id))
         ? await Organisations.getOne(knex, { where: { _360GivingId: id } })
         : await Organisations.getOne(knex, { where: { id: Number(id) } });

--- a/api/src/api/v1/prerequisites/is_child_organisation.ts
+++ b/api/src/api/v1/prerequisites/is_child_organisation.ts
@@ -17,6 +17,10 @@ import { RoleEnum } from '../../../models/types';
 
 
 export default async (request: GetCommunityBusinessRequest, h: Hapi.ResponseToolkit) => {
+  if (request.auth.strategy === 'external') {
+    return false;
+  }
+
   const { roles } = StandardCredentials.fromRequest(request);
 
   if (roles.includes(RoleEnum.TWINE_ADMIN)) {

--- a/api/src/auth/strategies/external/index.ts
+++ b/api/src/auth/strategies/external/index.ts
@@ -1,7 +1,12 @@
 import validate, { ExternalCredentials } from './validate';
 import { ExternalAppCredentials } from './types';
 
+
+const name = 'external';
+
+
 export {
+  name,
   validate,
   ExternalAppCredentials,
   ExternalCredentials,

--- a/api/src/auth/strategies/external/types.ts
+++ b/api/src/auth/strategies/external/types.ts
@@ -2,5 +2,5 @@ import { Organisation } from '../../../models';
 
 export type ExternalAppCredentials = {
   scope: string[],
-  app: { organisation: Organisation },
+  organisation: Organisation,
 };

--- a/api/src/auth/strategies/external/types.ts
+++ b/api/src/auth/strategies/external/types.ts
@@ -1,5 +1,9 @@
 import { Organisation } from '../../../models';
 
+declare module '@hapi/hapi' {
+  interface AppCredentials extends ExternalAppCredentials {}
+}
+
 export type ExternalAppCredentials = {
   scope: string[],
   organisation: Organisation,

--- a/api/src/auth/strategies/external/types.ts
+++ b/api/src/auth/strategies/external/types.ts
@@ -1,14 +1,6 @@
-declare module '@hapi/hapi' {
-  interface AppCredentials extends ExternalAppCredentials {}
-}
+import { Organisation } from '../../../models';
 
 export type ExternalAppCredentials = {
   scope: string[],
-  app: 'frontline',
-};
-
-export type ApiTokenRow = {
-  api_token: string,
-  api_token_access: string,
-  api_token_name: string,
+  app: { organisation: Organisation },
 };

--- a/api/src/auth/strategies/external/validate.ts
+++ b/api/src/auth/strategies/external/validate.ts
@@ -7,11 +7,11 @@ export const ExternalCredentials = {
   async get (knex: Knex, token: string): Promise<Hapi.AuthCredentials> {
     const match = await ApiTokens.find(knex, token);
     const org = await Organisations.getOne(knex, { where: { name: match.name } });
-    return { scope: [match.access], app: { scope: [match.access], app: { organisation: org } } };
+    return { scope: [match.access], app: { scope: [match.access], organisation: org } };
   },
 
   fromRequest (req: Hapi.Request) {
-    return Object.assign({ scope: req.auth.credentials.scope }, req.auth.credentials.app.app);
+    return Object.assign({ scope: req.auth.credentials.scope }, req.auth.credentials.app);
   },
 };
 

--- a/api/src/auth/strategies/standard/credentials.ts
+++ b/api/src/auth/strategies/standard/credentials.ts
@@ -21,6 +21,6 @@ export const Credentials: ICredentials = {
   },
 
   fromRequest (req) {
-    return Object.assign({ scope: req.auth.credentials.scope }, req.auth.credentials.user) as any;
+    return Object.assign({ scope: req.auth.credentials.scope }, req.auth.credentials.user);
   },
 };

--- a/api/src/auth/strategies/standard/index.ts
+++ b/api/src/auth/strategies/standard/index.ts
@@ -3,7 +3,11 @@ import { Sessions } from './session';
 import { Credentials } from './credentials';
 
 
+const name = 'standard';
+
+
 export {
+  name,
   validate,
   Sessions,
   Credentials,

--- a/api/src/models/__tests__/apiToken.test.integration.ts
+++ b/api/src/models/__tests__/apiToken.test.integration.ts
@@ -43,11 +43,13 @@ describe('API Tokens Model', () => {
     });
 
     test('does not return tokens marked as deleted', async () => {
-      expect.assertions(1);
+      expect.assertions(2);
 
       const res = await trx('api_token')
         .update({ deleted_at: new Date() })
         .where({ api_token_name: 'Aperture Science' });
+
+      expect(res).toBe(1);
 
       try {
         await ApiTokens.find(trx, 'aperture-token');

--- a/api/src/models/__tests__/apiToken.test.integration.ts
+++ b/api/src/models/__tests__/apiToken.test.integration.ts
@@ -1,0 +1,112 @@
+import * as Knex from 'knex';
+import { getConfig } from '../../../config';
+import { getTrx } from '../../../tests/utils/database';
+import { ApiTokens } from '../apiToken';
+
+describe('API Tokens Model', () => {
+  const config = getConfig(process.env.NODE_ENV);
+  const knex = Knex(config.knex);
+  let trx: Knex.Transaction;
+
+  afterAll(async () => {
+    await knex.destroy();
+  });
+
+  beforeEach(async () => {
+    trx = await getTrx(knex);
+  });
+
+  afterEach(async () => {
+    await trx.rollback();
+  });
+
+  describe('find', () => {
+    test('can find token that exists', async () => {
+      const token = await ApiTokens.find(trx, 'aperture-token');
+      expect(token).toEqual(expect.objectContaining({
+        name: 'Aperture Science',
+        access: 'api:visitor:read',
+        id: 3,
+        modifiedAt: null,
+        deletedAt: null,
+      }));
+    });
+
+    test('rejects if token cannot be found', async () => {
+      expect.assertions(1);
+
+      try {
+        await ApiTokens.find(trx, 'does not exist');
+      } catch (error) {
+        expect(error).toBeTruthy();
+      }
+    });
+
+    test('does not return tokens marked as deleted', async () => {
+      expect.assertions(1);
+
+      const res = await trx('api_token')
+        .update({ deleted_at: new Date() })
+        .where({ api_token_name: 'Aperture Science' });
+
+      try {
+        await ApiTokens.find(trx, 'aperture-token');
+      } catch (error) {
+        expect(error).toBeTruthy();
+      }
+    });
+  });
+
+  describe('create', () => {
+    test('creates ApiToken object with random token', () => {
+      const token = ApiTokens.create('foo', 'bar');
+
+      expect(token).toEqual(expect.objectContaining({
+        name: 'foo',
+        access: 'bar',
+        token: expect.stringContaining(''),
+      }));
+      expect(token.token).toHaveLength(32);
+    });
+  });
+
+  describe('add', () => {
+    test('adds created token to api_token table', async () => {
+      const tknsBefore = await trx('api_token').select('*');
+
+      const rawToken = await ApiTokens.create('foo', 'bar');
+      const token = await ApiTokens.add(trx, rawToken);
+      const found = await ApiTokens.find(trx, rawToken.token);
+
+      const tknsAfter = await trx('api_token').select('*');
+
+      expect(token).toEqual(expect.objectContaining({
+        id: tknsBefore.length + 1,
+        name: 'foo',
+        access: 'bar',
+        token: expect.stringContaining(''),
+        modifiedAt: null,
+        deletedAt: null,
+      }));
+      expect(found).toEqual(token);
+      expect(tknsBefore).toHaveLength(tknsAfter.length - 1);
+    });
+  });
+
+  describe('delete', () => {
+    test('marks token as deleted', async () => {
+      expect.assertions(2);
+
+      const token = await ApiTokens.find(trx, 'blackmesa-token');
+      const res = await ApiTokens.delete(trx, token);
+
+      expect(res).toEqual(1);
+
+      try {
+        await ApiTokens.find(trx, 'blackmesa-token');
+      } catch (error) {
+        expect(error).toBeTruthy();
+      }
+    });
+  });
+});

--- a/api/src/models/age.ts
+++ b/api/src/models/age.ts
@@ -1,4 +1,5 @@
-import moment = require('moment');
+import * as moment from 'moment';
+
 
 export const Age = {
   toBirthYear: (age: number) => moment().year() - age,

--- a/api/src/models/apiToken.ts
+++ b/api/src/models/apiToken.ts
@@ -1,0 +1,66 @@
+import * as Knex from 'knex';
+import { compare, hash } from 'bcrypt';
+import { Promises } from 'twine-util';
+import { ApiToken } from './types';
+import { randomBytes } from 'crypto';
+
+
+export const ApiTokens = {
+  async find (client: Knex, token: string): Promise<ApiToken> {
+    const tokens = await client('api_token')
+      .select({
+        id: 'api_token_id',
+        name: 'api_token_name',
+        token: 'api_token',
+        access: 'api_token_access',
+        createdAt: 'created_at',
+        modifiedAt: 'modified_at',
+        deletedAt: 'deleted_at',
+      })
+      .where({ deleted_at: null });
+
+    return Promises.find<ApiToken>((tkn) => compare(token, tkn.token), tokens);
+  },
+
+  create (name: string, access: string): Partial<ApiToken> {
+    return {
+      token: randomBytes(16).toString('hex'),
+      name,
+      access,
+    };
+  },
+
+  async add (client: Knex, token: Partial<ApiToken>): Promise<ApiToken> {
+    const hashedToken = await hash(token, 12);
+    const [res] = await client('api_token')
+      .insert({
+        api_token: hashedToken,
+        api_token_access: token.access,
+        api_token_name: token.name,
+      })
+      .returning('*');
+
+    return {
+      id: res.api_token_id,
+      name: res.api_token_name,
+      access: res.api_token_access,
+      token: res.api_token,
+      createdAt: res.created_at,
+      modifiedAt: res.modified_at,
+      deletedAt: res.deleted_at,
+    };
+  },
+
+  async delete (client: Knex, token: ApiToken): Promise<number> {
+    if (token.id) {
+      return client('api_token')
+        .update({ deleted_at: new Date() })
+        .where({ api_token_id: token.id });
+
+    } else {
+      const tkn = await ApiTokens.find(client, token.token);
+      return ApiTokens.delete(client, tkn);
+
+    }
+  },
+};

--- a/api/src/models/apiToken.ts
+++ b/api/src/models/apiToken.ts
@@ -31,7 +31,7 @@ export const ApiTokens = {
   },
 
   async add (client: Knex, token: Partial<ApiToken>): Promise<ApiToken> {
-    const hashedToken = await hash(token, 12);
+    const hashedToken = await hash(token.token, 12);
     const [res] = await client('api_token')
       .insert({
         api_token: hashedToken,

--- a/api/src/models/index.ts
+++ b/api/src/models/index.ts
@@ -5,6 +5,7 @@ export { CbAdmins } from './cb_admin';
 export { Organisations } from './organisation';
 export { CommunityBusinesses } from './community_business';
 export { VolunteerLogs } from './volunteer_log';
+export { ApiTokens } from './apiToken';
 
 export {
   User,

--- a/api/src/models/types.ts
+++ b/api/src/models/types.ts
@@ -142,6 +142,13 @@ export type CommunityBusinessRow = {
   'organisation.is_temp': boolean
 };
 
+export type ApiTokenRow = {
+  api_token: string,
+  api_token_access: string,
+  api_token_name: string,
+};
+
+
 /*
  * Base declarations
  *
@@ -275,6 +282,13 @@ export type VolunteerLog = Readonly<CommonTimestamps & {
   project?: string
   duration: Duration.Duration
   startedAt: string
+}>;
+
+export type ApiToken = Readonly<CommonTimestamps & {
+  id: Int
+  name: string
+  access: string
+  token: string
 }>;
 
 


### PR DESCRIPTION
Fixes #199 

### Changes
- Add simple `ApiTokens` model
- Update `external` strategy and `AppCredentials` definition
- Update route pre-requisites to handle `external` strategy
- Added `external` access to the following routes:
  - `GET /community-businesses/me`
  - `GET /community-businesses/me/visitors`
  - `GET /community-businesses/me/visitors/:id`
  - `GET /community-businesses/me/feedback`
  - `GET /community-businesses/me/feedback/aggregates`
  - `GET /community-businesses/me/visit-activities`
  - `GET /community-businesses/me/visit-logs`
  - `GET /community-businesses/me/visit-logs/aggregates`
- Add script to add API token from command line

### Testing Requirements
**Apps**: API
**Steps**
- Generate new API token for org with cmd line script
- Use token to make a request to the API to one (or all) of the above routes
- Check that they are all permitted
- Try to access other routes, check that you get a 401/403

### Release/Comms Requirements
- Send e-mail to client that requested this feature informing them it's live and offering instructions and their API key.