### PR TITLE
👀 monitor visitor sign in type

### DIFF
--- a/api/database/index.ts
+++ b/api/database/index.ts
@@ -62,7 +62,7 @@ export const migrate = {
         'ENUM_access_type',
         'ENUM_invitation_status',
         'ENUM_subscription_status',
-        'ENUM_visitor_log_attendance_type',
+        'ENUM_visitor_log_sign_in_type',
       ]
         .map(tap((t) => {
           if (config.env !== Environment.TESTING) console.log(`Dropping type ${t}`);

--- a/api/database/index.ts
+++ b/api/database/index.ts
@@ -62,6 +62,7 @@ export const migrate = {
         'ENUM_access_type',
         'ENUM_invitation_status',
         'ENUM_subscription_status',
+        'ENUM_visitor_log_attendance_type',
       ]
         .map(tap((t) => {
           if (config.env !== Environment.TESTING) console.log(`Dropping type ${t}`);

--- a/api/database/migrations/20190801_track_visitor_sign_in_type.ts
+++ b/api/database/migrations/20190801_track_visitor_sign_in_type.ts
@@ -1,0 +1,3 @@
+import { buildQueryFromFile } from '../utils';
+exports.up = buildQueryFromFile(__filename);
+exports.down = () => {};

--- a/api/database/migrations/sql/20190801_track_visitor_sign_in_type.sql
+++ b/api/database/migrations/sql/20190801_track_visitor_sign_in_type.sql
@@ -1,0 +1,19 @@
+/*
+ * Track sign in type on visitor app
+ */
+
+-- NB: will need editing if batch login is implemented
+
+CREATE TYPE ENUM_visitor_log_attendance_type AS ENUM ('sign_in_with_name', 'qr_code');
+
+CREATE TABLE visit_log_attendance (
+  visit_log_attendance_id   SERIAL NOT NULL UNIQUE,
+  visit_log_id              INT NOT NULL,
+  attendance_type           ENUM_visitor_log_attendance_type,
+  created_at                TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  modified_at               TIMESTAMP WITH TIME ZONE,
+  deleted_at                TIMESTAMP WITH TIME ZONE,
+
+  CONSTRAINT visit_log_attendance_pk                 PRIMARY KEY (visit_log_attendance_id),
+  CONSTRAINT visit_log_attendance_to_visit_log_fk    FOREIGN KEY (visit_log_id) REFERENCES visit_log ON DELETE CASCADE
+);

--- a/api/database/migrations/sql/20190801_track_visitor_sign_in_type.sql
+++ b/api/database/migrations/sql/20190801_track_visitor_sign_in_type.sql
@@ -4,12 +4,12 @@
 
 -- NB: will need editing if batch login is implemented
 
-CREATE TYPE ENUM_visitor_log_attendance_type AS ENUM ('sign_in_with_name', 'qr_code');
+CREATE TYPE ENUM_visitor_log_sign_in_type AS ENUM ('sign_in_with_name', 'qr_code');
 
 CREATE TABLE visit_log_attendance (
   visit_log_attendance_id   SERIAL NOT NULL UNIQUE,
   visit_log_id              INT NOT NULL,
-  attendance_type           ENUM_visitor_log_attendance_type,
+  sign_in_type           ENUM_visitor_log_sign_in_type,
   created_at                TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
   modified_at               TIMESTAMP WITH TIME ZONE,
   deleted_at                TIMESTAMP WITH TIME ZONE,

--- a/api/src/api/v1/community_businesses/__tests__/visit_logs.test.integration.ts
+++ b/api/src/api/v1/community_businesses/__tests__/visit_logs.test.integration.ts
@@ -48,6 +48,7 @@ describe('API v1 :: Community Businesses :: Visit Logs', () => {
         payload: {
           userId: 1,
           visitActivityId: 2,
+          attendanceType: 'sign_in_with_name',
         },
         credentials,
       }));
@@ -65,6 +66,7 @@ describe('API v1 :: Community Businesses :: Visit Logs', () => {
         payload: {
           userId: 2,
           visitActivityId: 2,
+          attendanceType: 'sign_in_with_name',
         },
         credentials,
       }));
@@ -81,6 +83,7 @@ describe('API v1 :: Community Businesses :: Visit Logs', () => {
         payload: {
           userId: 1,
           visitActivityId: 200,
+          attendanceType: 'sign_in_with_name',
         },
         credentials,
       }));

--- a/api/src/api/v1/community_businesses/__tests__/visit_logs.test.integration.ts
+++ b/api/src/api/v1/community_businesses/__tests__/visit_logs.test.integration.ts
@@ -48,7 +48,7 @@ describe('API v1 :: Community Businesses :: Visit Logs', () => {
         payload: {
           userId: 1,
           visitActivityId: 2,
-          attendanceType: 'sign_in_with_name',
+          signInType: 'sign_in_with_name',
         },
         credentials,
       }));
@@ -66,7 +66,7 @@ describe('API v1 :: Community Businesses :: Visit Logs', () => {
         payload: {
           userId: 2,
           visitActivityId: 2,
-          attendanceType: 'sign_in_with_name',
+          signInType: 'sign_in_with_name',
         },
         credentials,
       }));
@@ -83,7 +83,7 @@ describe('API v1 :: Community Businesses :: Visit Logs', () => {
         payload: {
           userId: 1,
           visitActivityId: 200,
-          attendanceType: 'sign_in_with_name',
+          signInType: 'sign_in_with_name',
         },
         credentials,
       }));

--- a/api/src/api/v1/community_businesses/temporary/__tests__/delete.test.integration.ts
+++ b/api/src/api/v1/community_businesses/temporary/__tests__/delete.test.integration.ts
@@ -121,7 +121,7 @@ describe('DELETE /community-businesses/temporary/:id', () => {
       payload: {
         userId: visitor.id,
         visitActivityId: visitActity.id,
-        attendanceType: 'qr_code',
+        signInType: 'qr_code',
       },
       credentials: tempCredentials,
     }));

--- a/api/src/api/v1/community_businesses/temporary/__tests__/delete.test.integration.ts
+++ b/api/src/api/v1/community_businesses/temporary/__tests__/delete.test.integration.ts
@@ -121,6 +121,7 @@ describe('DELETE /community-businesses/temporary/:id', () => {
       payload: {
         userId: visitor.id,
         visitActivityId: visitActity.id,
+        attendanceType: 'qr_code',
       },
       credentials: tempCredentials,
     }));

--- a/api/src/api/v1/community_businesses/visit_logs.ts
+++ b/api/src/api/v1/community_businesses/visit_logs.ts
@@ -14,13 +14,13 @@ import { ApiRequestQuery } from '../schema/request';
 import Roles from '../../../models/role';
 import { RoleEnum } from '../../../models/types';
 
-export type VisitsignInType = 'sign_in_with_name' | 'qr_code';
+export type VisitSignInType = 'sign_in_with_name' | 'qr_code';
 
 interface PostVisitLogRequest extends Hapi.Request {
   payload: {
     userId: number
     visitActivityId: number
-    signInType: VisitsignInType
+    signInType: VisitSignInType
   };
 }
 

--- a/api/src/api/v1/community_businesses/visit_logs.ts
+++ b/api/src/api/v1/community_businesses/visit_logs.ts
@@ -1,5 +1,6 @@
 import * as Hapi from '@hapi/hapi';
 import * as Boom from '@hapi/boom';
+import * as Joi from '@hapi/joi';
 import { omit, filter, complement, isEmpty } from 'ramda';
 import { query, response, id } from './schema';
 import {
@@ -13,10 +14,13 @@ import { ApiRequestQuery } from '../schema/request';
 import Roles from '../../../models/role';
 import { RoleEnum } from '../../../models/types';
 
-interface VisitorSearchRequest extends Hapi.Request {
+export type VisitAttendanceType = 'sign_in_with_name' | 'qr_code';
+
+interface PostVisitLogRequest extends Hapi.Request {
   payload: {
     userId: number
     visitActivityId: number
+    attendanceType: VisitAttendanceType
   };
 }
 
@@ -46,6 +50,7 @@ const routes: Hapi.ServerRoute[] = [
         payload: {
           userId: id.required(),
           visitActivityId: id.required(),
+          attendanceType: Joi.string().valid(['sign_in_with_name', 'qr_code']).required(),
         },
       },
       response: { schema: response },
@@ -53,8 +58,10 @@ const routes: Hapi.ServerRoute[] = [
         { method: getCommunityBusiness, assign: 'communityBusiness' },
       ],
     },
-    handler: async (request: VisitorSearchRequest, h) => {
-      const { payload: { userId, visitActivityId }, server: { app: { knex } } } = request;
+    handler: async (request: PostVisitLogRequest, h) => {
+      const {
+        payload: { userId, visitActivityId, attendanceType },
+        server: { app: { knex } } } = request;
       const communityBusiness = <CommunityBusiness> request.pre.communityBusiness;
 
       const visitor = await Visitors.getOne(knex, { where: { id: userId } });
@@ -79,7 +86,7 @@ const routes: Hapi.ServerRoute[] = [
         return Boom.badRequest('Activity not associated to Community Business');
       }
 
-      return CommunityBusinesses.addVisitLog(knex, activity, visitor);
+      return CommunityBusinesses.addVisitLog(knex, activity, visitor, attendanceType);
     },
   },
   {

--- a/api/src/api/v1/community_businesses/visit_logs.ts
+++ b/api/src/api/v1/community_businesses/visit_logs.ts
@@ -14,13 +14,13 @@ import { ApiRequestQuery } from '../schema/request';
 import Roles from '../../../models/role';
 import { RoleEnum } from '../../../models/types';
 
-export type VisitAttendanceType = 'sign_in_with_name' | 'qr_code';
+export type VisitsignInType = 'sign_in_with_name' | 'qr_code';
 
 interface PostVisitLogRequest extends Hapi.Request {
   payload: {
     userId: number
     visitActivityId: number
-    attendanceType: VisitAttendanceType
+    signInType: VisitsignInType
   };
 }
 
@@ -50,7 +50,7 @@ const routes: Hapi.ServerRoute[] = [
         payload: {
           userId: id.required(),
           visitActivityId: id.required(),
-          attendanceType: Joi.string().valid(['sign_in_with_name', 'qr_code']).required(),
+          signInType: Joi.string().valid(['sign_in_with_name', 'qr_code']).required(),
         },
       },
       response: { schema: response },
@@ -60,7 +60,7 @@ const routes: Hapi.ServerRoute[] = [
     },
     handler: async (request: PostVisitLogRequest, h) => {
       const {
-        payload: { userId, visitActivityId, attendanceType },
+        payload: { userId, visitActivityId, signInType },
         server: { app: { knex } } } = request;
       const communityBusiness = <CommunityBusiness> request.pre.communityBusiness;
 
@@ -86,7 +86,7 @@ const routes: Hapi.ServerRoute[] = [
         return Boom.badRequest('Activity not associated to Community Business');
       }
 
-      return CommunityBusinesses.addVisitLog(knex, activity, visitor, attendanceType);
+      return CommunityBusinesses.addVisitLog(knex, activity, visitor, signInType);
     },
   },
   {

--- a/api/src/models/__tests__/community_business.test.integration.ts
+++ b/api/src/models/__tests__/community_business.test.integration.ts
@@ -9,6 +9,7 @@ import { Dictionary, omit } from 'ramda';
 import { RegionEnum, SectorEnum, RoleEnum } from '../types';
 import { CbAdmins } from '../cb_admin';
 import Roles from '../role';
+import { Visitors } from '../visitor';
 
 
 describe('Community Business Model', () => {
@@ -220,6 +221,36 @@ describe('Community Business Model', () => {
       expect(deletedOrgs[0].id).toBe(1);
       expect(deletedOrgs[0].modifiedAt).not.toEqual(null);
       expect(deletedOrgs[0].deletedAt).not.toEqual(null);
+    });
+
+    describe('addVisitLog', () => {
+      test(':: adds visit log', async () => {
+        const cb = await CommunityBusinesses.getOne(trx, { where: { name: 'Aperture Science' } });
+        const activity = await CommunityBusinesses.getVisitActivityById(trx, cb, 1);
+        const visitor = await Visitors.getOne(trx, { where: { name: 'Chell' } });
+        const log = await CommunityBusinesses.addVisitLog(trx, activity, visitor, 'qr_code');
+        expect(log).toEqual(expect.objectContaining({
+          id: 12,
+          userId: 1,
+          visitActivityId: 1,
+        }));
+      });
+      test(':: tracks sign in type', async () => {
+        const cb = await CommunityBusinesses.getOne(trx, { where: { name: 'Aperture Science' } });
+        const activity = await CommunityBusinesses.getVisitActivityById(trx, cb, 1);
+        const visitor = await Visitors.getOne(trx, { where: { name: 'Chell' } });
+        const log = await CommunityBusinesses.addVisitLog(trx, activity, visitor, 'qr_code');
+
+        const [attendanceTypeEntry] = await trx('visit_log_attendance')
+          .select('*')
+          .where({ visit_log_id: log.id });
+
+        expect(attendanceTypeEntry).toEqual(expect.objectContaining({
+          visit_log_attendance_id: 2,
+          attendance_type: 'qr_code',
+          visit_log_id: 13,
+        }));
+      });
     });
   });
 
@@ -456,4 +487,5 @@ describe('Community Business Model', () => {
       expect(cbs2).toHaveLength(1);
     });
   });
+
 });

--- a/api/src/models/__tests__/community_business.test.integration.ts
+++ b/api/src/models/__tests__/community_business.test.integration.ts
@@ -241,13 +241,13 @@ describe('Community Business Model', () => {
         const visitor = await Visitors.getOne(trx, { where: { name: 'Chell' } });
         const log = await CommunityBusinesses.addVisitLog(trx, activity, visitor, 'qr_code');
 
-        const [attendanceTypeEntry] = await trx('visit_log_attendance')
+        const [signInTypeEntry] = await trx('visit_log_attendance')
           .select('*')
           .where({ visit_log_id: log.id });
 
-        expect(attendanceTypeEntry).toEqual(expect.objectContaining({
+        expect(signInTypeEntry).toEqual(expect.objectContaining({
           visit_log_attendance_id: 2,
-          attendance_type: 'qr_code',
+          sign_in_type: 'qr_code',
           visit_log_id: 13,
         }));
       });

--- a/api/src/models/community_business.ts
+++ b/api/src/models/community_business.ts
@@ -480,7 +480,7 @@ export const CommunityBusinesses: CommunityBusinessCollection = {
     return res || null;
   },
 
-  async addVisitLog (client, visitActivity, user, attendanceType) {
+  async addVisitLog (client, visitActivity, user, signInType) {
     const res = await client.transaction(async (trx) => {
       const [log] = await trx('visit_log')
         .insert({
@@ -499,7 +499,7 @@ export const CommunityBusinesses: CommunityBusinessCollection = {
       await trx('visit_log_attendance')
         .insert({
           visit_log_id: log.id,
-          attendance_type: attendanceType,
+          sign_in_type: signInType,
         });
 
       return log;

--- a/api/src/models/types.ts
+++ b/api/src/models/types.ts
@@ -6,7 +6,7 @@ import { Maybe, Dictionary, Float, Int, Omit, Map } from '../types/internal';
 import { PermissionLevelEnum } from '../auth';
 import { AccessEnum, ResourceEnum } from '../auth/types';
 import { Duration } from 'twine-util';
-import { VisitsignInType } from '../api/v1/community_businesses/visit_logs';
+import { VisitSignInType } from '../api/v1/community_businesses/visit_logs';
 
 /*
  * Common and utility types
@@ -367,7 +367,7 @@ export type CommunityBusinessCollection = Collection<CommunityBusiness> & {
     => Promise<Maybe<VisitActivity>>;
   updateVisitActivity: (k: Knex, a: Partial<VisitActivity>) => Promise<Maybe<VisitActivity>>;
   deleteVisitActivity: (k: Knex, i: Int) => Promise<Maybe<VisitActivity>>;
-  addVisitLog: (k: Knex, v: VisitActivity, u: Partial<User>, a: VisitsignInType) =>
+  addVisitLog: (k: Knex, v: VisitActivity, u: Partial<User>, a: VisitSignInType) =>
     Promise<VisitEvent>;
   // TODO [getVisitLogsWithUsers]:
   // this is still wrong, we return "category", which is missing

--- a/api/src/models/types.ts
+++ b/api/src/models/types.ts
@@ -6,7 +6,7 @@ import { Maybe, Dictionary, Float, Int, Omit, Map } from '../types/internal';
 import { PermissionLevelEnum } from '../auth';
 import { AccessEnum, ResourceEnum } from '../auth/types';
 import { Duration } from 'twine-util';
-import { VisitAttendanceType } from '../api/v1/community_businesses/visit_logs';
+import { VisitsignInType } from '../api/v1/community_businesses/visit_logs';
 
 /*
  * Common and utility types
@@ -367,7 +367,7 @@ export type CommunityBusinessCollection = Collection<CommunityBusiness> & {
     => Promise<Maybe<VisitActivity>>;
   updateVisitActivity: (k: Knex, a: Partial<VisitActivity>) => Promise<Maybe<VisitActivity>>;
   deleteVisitActivity: (k: Knex, i: Int) => Promise<Maybe<VisitActivity>>;
-  addVisitLog: (k: Knex, v: VisitActivity, u: Partial<User>, a: VisitAttendanceType) =>
+  addVisitLog: (k: Knex, v: VisitActivity, u: Partial<User>, a: VisitsignInType) =>
     Promise<VisitEvent>;
   // TODO [getVisitLogsWithUsers]:
   // this is still wrong, we return "category", which is missing

--- a/api/src/models/types.ts
+++ b/api/src/models/types.ts
@@ -6,6 +6,7 @@ import { Maybe, Dictionary, Float, Int, Omit, Map } from '../types/internal';
 import { PermissionLevelEnum } from '../auth';
 import { AccessEnum, ResourceEnum } from '../auth/types';
 import { Duration } from 'twine-util';
+import { VisitAttendanceType } from '../api/v1/community_businesses/visit_logs';
 
 /*
  * Common and utility types
@@ -366,7 +367,8 @@ export type CommunityBusinessCollection = Collection<CommunityBusiness> & {
     => Promise<Maybe<VisitActivity>>;
   updateVisitActivity: (k: Knex, a: Partial<VisitActivity>) => Promise<Maybe<VisitActivity>>;
   deleteVisitActivity: (k: Knex, i: Int) => Promise<Maybe<VisitActivity>>;
-  addVisitLog: (k: Knex, v: VisitActivity, u: Partial<User>) => Promise<VisitEvent>;
+  addVisitLog: (k: Knex, v: VisitActivity, u: Partial<User>, a: VisitAttendanceType) =>
+    Promise<VisitEvent>;
   // TODO [getVisitLogsWithUsers]:
   // this is still wrong, we return "category", which is missing
   getVisitLogsWithUsers: (k: Knex, c: CommunityBusiness, q?: ModelQuery<LinkedVisitEvent & User>) =>

--- a/visitor-app/src/api/index.js
+++ b/visitor-app/src/api/index.js
@@ -114,12 +114,13 @@ export const Visitors = {
   sendQrCode: ({ id } = {}) =>
     axios.post(`/community-businesses/me/visitors/${id}/emails`, { type: 'qrcode' }),
 
-  createVisit: ({ visitorId, activityId } = {}) =>
+  createVisit: ({ visitorId, activityId, attendanceType } = {}) =>
     axios.post(
       '/community-businesses/me/visit-logs',
       {
         userId: visitorId,
         visitActivityId: activityId,
+        attendanceType,
       },
     ),
   addRole: ({ userId, organisationId, role, token } = {}) =>

--- a/visitor-app/src/api/index.js
+++ b/visitor-app/src/api/index.js
@@ -114,13 +114,13 @@ export const Visitors = {
   sendQrCode: ({ id } = {}) =>
     axios.post(`/community-businesses/me/visitors/${id}/emails`, { type: 'qrcode' }),
 
-  createVisit: ({ visitorId, activityId, attendanceType } = {}) =>
+  createVisit: ({ visitorId, activityId, signInType } = {}) =>
     axios.post(
       '/community-businesses/me/visit-logs',
       {
         userId: visitorId,
         visitActivityId: activityId,
-        attendanceType,
+        signInType,
       },
     ),
   addRole: ({ userId, organisationId, role, token } = {}) =>

--- a/visitor-app/src/visitors/pages/SignIn/SignInForm.js
+++ b/visitor-app/src/visitors/pages/SignIn/SignInForm.js
@@ -96,7 +96,7 @@ export default class SignInForm extends React.Component {
           return this.setState(evolve({ fields: concatUnlessExists(nextField) }));
         }
 
-        return onSuccess(res.data.result[0]); // { id, name }
+        return onSuccess({ ...res.data.result[0], attendanceType: 'sign_in_with_name' }); // { id, name }
       })
       .catch((err) => {
         this.setState({ isFetching: false });

--- a/visitor-app/src/visitors/pages/SignIn/SignInForm.js
+++ b/visitor-app/src/visitors/pages/SignIn/SignInForm.js
@@ -96,7 +96,7 @@ export default class SignInForm extends React.Component {
           return this.setState(evolve({ fields: concatUnlessExists(nextField) }));
         }
 
-        return onSuccess({ ...res.data.result[0], attendanceType: 'sign_in_with_name' }); // { id, name }
+        return onSuccess({ ...res.data.result[0], signInType: 'sign_in_with_name' }); // { id, name }
       })
       .catch((err) => {
         this.setState({ isFetching: false });

--- a/visitor-app/src/visitors/pages/SignIn/index.js
+++ b/visitor-app/src/visitors/pages/SignIn/index.js
@@ -55,6 +55,7 @@ export default class SignIn extends Component {
       qrCodeContent: '',
       activities: [],
       errors: {},
+      attendanceType: null,
     };
   }
 
@@ -82,11 +83,13 @@ export default class SignIn extends Component {
   }
 
   onSignInSuccess = (res) => {
+    console.log({ res });
     this.setState({
       hasSignedIn: true,
       visitorName: res.name,
       visitorId: res.id,
       qrCodeContent: res.qrCodeContent,
+      attendanceType: res.attendanceType,
     });
   }
 
@@ -104,6 +107,7 @@ export default class SignIn extends Component {
         return this.onSignInSuccess({
           ...res.data.result,
           qrCodeContent: content,
+          attendanceType: 'qr_code',
         });
       })
       .catch(err => redirectOnError(this.props.history.push, err, { default: '/visitor/qrerror' }));
@@ -118,9 +122,11 @@ export default class SignIn extends Component {
       this.props.history.push('/error/unknown');
     }
 
+    console.log(this.state);
     Visitors.createVisit({
       activityId: activity.id,
       visitorId: this.state.visitorId,
+      attendanceType: this.state.attendanceType,
     })
       .then(() => this.props.history.push('/visitor/end'))
       .catch(err => redirectOnError(this.props.history.push, err));

--- a/visitor-app/src/visitors/pages/SignIn/index.js
+++ b/visitor-app/src/visitors/pages/SignIn/index.js
@@ -83,7 +83,6 @@ export default class SignIn extends Component {
   }
 
   onSignInSuccess = (res) => {
-    console.log({ res });
     this.setState({
       hasSignedIn: true,
       visitorName: res.name,
@@ -122,7 +121,6 @@ export default class SignIn extends Component {
       this.props.history.push('/error/unknown');
     }
 
-    console.log(this.state);
     Visitors.createVisit({
       activityId: activity.id,
       visitorId: this.state.visitorId,

--- a/visitor-app/src/visitors/pages/SignIn/index.js
+++ b/visitor-app/src/visitors/pages/SignIn/index.js
@@ -55,7 +55,7 @@ export default class SignIn extends Component {
       qrCodeContent: '',
       activities: [],
       errors: {},
-      attendanceType: null,
+      signInType: null,
     };
   }
 
@@ -89,7 +89,7 @@ export default class SignIn extends Component {
       visitorName: res.name,
       visitorId: res.id,
       qrCodeContent: res.qrCodeContent,
-      attendanceType: res.attendanceType,
+      signInType: res.signInType,
     });
   }
 
@@ -107,7 +107,7 @@ export default class SignIn extends Component {
         return this.onSignInSuccess({
           ...res.data.result,
           qrCodeContent: content,
-          attendanceType: 'qr_code',
+          signInType: 'qr_code',
         });
       })
       .catch(err => redirectOnError(this.props.history.push, err, { default: '/visitor/qrerror' }));
@@ -126,7 +126,7 @@ export default class SignIn extends Component {
     Visitors.createVisit({
       activityId: activity.id,
       visitorId: this.state.visitorId,
-      attendanceType: this.state.attendanceType,
+      signInType: this.state.signInType,
     })
       .then(() => this.props.history.push('/visitor/end'))
       .catch(err => redirectOnError(this.props.history.push, err));


### PR DESCRIPTION
**NOTE:** Dates for migration may need editing depending on whether this PR or #227 goes in first

fixes #226

### Changes
- create table to track visitor sign in type
- visitor app req specifies sign in type
- store sign in type to db

### Testing Requirements
- [x] Visitor App
  - log in visitor with QR code
  - log in visitor with sign in with name
  - manually check db is updates (optional)

### Release Requirements
- no restrictions. 
- deploy when ready.

### Manual Deployment
- [ ] Visitor App
- [ ] API
