### PR TITLE
🕸 add webhook endpoint for heroku releases

### DIFF
--- a/api/config/__tests__/index.test.ts
+++ b/api/config/__tests__/index.test.ts
@@ -157,6 +157,11 @@ describe('Config', () => {
       qrcode: {
         secret: 'wftg4yj93g0irwfone49t2jwfeefwrgeijot3efwrtnjkbh',
       },
+      webhooks: {
+        heroku: {
+          secret: 'wftg4yj93g0irwfone49t2jwfeefwrgeijot3efwrtnjkbh',
+        },
+      },
     };
 
     expect(() => validateConfig(cfg)).not.toThrow();
@@ -223,6 +228,11 @@ describe('Config', () => {
       },
       qrcode: {
         secret: 'wftg4yj93g0irwfone49t2jwfeefwrgeijot3efwrtnjkbh',
+      },
+      webhooks: {
+        heroku: {
+          secret: 'wftg4yj93g0irwfone49t2jwfeefwrgeijot3efwrtnjkbh',
+        },
       },
     };
 

--- a/api/config/__tests__/index.test.ts
+++ b/api/config/__tests__/index.test.ts
@@ -140,6 +140,7 @@ describe('Config', () => {
       email: {
         postmarkKey: 'foo',
         fromAddress: 'boo@coo.com',
+        developers: ['boo@coo.com', 'hi@yo.com'],
       },
       auth: {
         schema: {
@@ -206,6 +207,7 @@ describe('Config', () => {
       email: {
         postmarkKey: '',
         fromAddress: 'fooo',
+        developers: ['boo@coo.com', 'hi@yo.com'],
       },
       auth: {
         schema: {

--- a/api/config/config.defaults.ts
+++ b/api/config/config.defaults.ts
@@ -83,7 +83,7 @@ const config: DeepPartial<Config> = {
   },
   email: {
     fromAddress: envOr('EMAIL_FROM_ADDRESS', 'visitorapp@powertochange.org.uk'),
-    developers: envListOr('DEVELOPER_EMAILS', ['', ''], ','),
+    developers: envListOr('DEVELOPER_EMAILS', ['one', 'two'], ','),
   },
   webhooks: {
     heroku: {

--- a/api/config/config.defaults.ts
+++ b/api/config/config.defaults.ts
@@ -83,7 +83,7 @@ const config: DeepPartial<Config> = {
   },
   email: {
     fromAddress: envOr('EMAIL_FROM_ADDRESS', 'visitorapp@powertochange.org.uk'),
-    developers: envListOr('DEVELOPER_EMAILS', ['one', 'two'], ','),
+    developers: envListOr('DEVELOPER_EMAILS', [], ','),
   },
   webhooks: {
     heroku: {

--- a/api/config/config.defaults.ts
+++ b/api/config/config.defaults.ts
@@ -7,7 +7,7 @@
 import * as path from 'path';
 import { Environment, Config } from './types';
 import { DeepPartial, AppEnum } from '../src/types/internal';
-import { envOr } from './util';
+import { envOr, envListOr } from './util';
 
 const config: DeepPartial<Config> = {
   root: path.resolve(__dirname, '..'),
@@ -83,6 +83,12 @@ const config: DeepPartial<Config> = {
   },
   email: {
     fromAddress: envOr('EMAIL_FROM_ADDRESS', 'visitorapp@powertochange.org.uk'),
+    developers: envListOr('DEVELOPER_EMAILS', ['', ''], ','),
+  },
+  webhooks: {
+    heroku: {
+      secret: envOr('HEROKU_WEBHOOK_SECRET', 'nosecretisethereatthemomentpleaseaddone'),
+    },
   },
 };
 

--- a/api/config/config.schema.ts
+++ b/api/config/config.schema.ts
@@ -82,7 +82,7 @@ export default Joi.object({
   email: Joi.object({
     postmarkKey: Joi.string().required(),
     fromAddress: Joi.string().email().required(),
-    developers: Joi.array().items(Joi.string()).length(2),
+    developers: Joi.array().items(Joi.string().email()),
   }).required(),
   auth: Joi.object({
     schema: {

--- a/api/config/config.schema.ts
+++ b/api/config/config.schema.ts
@@ -82,6 +82,7 @@ export default Joi.object({
   email: Joi.object({
     postmarkKey: Joi.string().required(),
     fromAddress: Joi.string().email().required(),
+    developers: Joi.array().items(Joi.string()).length(2),
   }).required(),
   auth: Joi.object({
     schema: {
@@ -107,5 +108,10 @@ export default Joi.object({
   }).required(),
   qrcode: Joi.object({
     secret: Joi.string().min(32).required(),
+  }).required(),
+  webhooks: Joi.object({
+    heroku: Joi.object({
+      secret: Joi.string().min(32).required(),
+    }).required(),
   }).required(),
 });

--- a/api/config/types.ts
+++ b/api/config/types.ts
@@ -35,6 +35,7 @@ type PlatformConfig = {
 type EmailConfig = {
   postmarkKey: string
   fromAddress: string
+  developers: string []
 };
 
 type AuthConfig = {
@@ -50,7 +51,13 @@ type QrCodeConfig = {
 };
 
 type CacheConfig = {
-  session: { name: string, options: CatboxRedisOptions }
+  session: { name: string, options: CatboxRedisOptions };
+};
+
+type WebHooksConfig = {
+  heroku: {
+    secret: string
+  }
 };
 
 export type Config = {
@@ -63,4 +70,5 @@ export type Config = {
   email: EmailConfig
   auth: AuthConfig
   qrcode: QrCodeConfig
+  webhooks: WebHooksConfig
 };

--- a/api/docs/configuration.md
+++ b/api/docs/configuration.md
@@ -67,6 +67,13 @@ VOLUNTEER_APP_DOMAIN=...
 # Supported environments testing | development | production
 
 NODE_ENV=...
+
+# Heroku Webhook Config
+
+# list of emails separated by ,
+DEVELOPER_EMAILS=...
+# secret supplied by heroku, contact team if this is needed
+HEROKU_WEBHOOK_SECRET=
 ```
 
 ### Note

--- a/api/src/api/v1/auth.ts
+++ b/api/src/api/v1/auth.ts
@@ -5,6 +5,7 @@ import * as Hapi from '@hapi/hapi';
 import SessionCookieSchema from '../../auth/schema/session_cookie';
 import * as standardStrategy from '../../auth/strategies/standard';
 import * as externalStrategy from '../../auth/strategies/external';
+import herokuWebhookStrategy from '../../auth/strategies/heroku_webhook';
 const AuthBearer = require('hapi-auth-bearer-token');
 
 
@@ -28,6 +29,14 @@ export default async (server: Hapi.Server) => {
    * External strategy
    */
   server.auth.strategy('external', 'bearer-access-token', { validate: externalStrategy.validate });
+
+  /*
+   * Heroku Webhook strategy
+   */
+
+  server.auth.strategy('herokuWebhook', 'bearer-access-token', {
+    validate: herokuWebhookStrategy,
+  });
 
   /*
    * Set default

--- a/api/src/auth/index.ts
+++ b/api/src/auth/index.ts
@@ -1,8 +1,9 @@
 import * as Standard from './strategies/standard';
 import * as External from './strategies/external';
+import * as HerokuWebHooks from './strategies/heroku_webhook';
 import { PermissionLevelEnum } from './types';
 
-const strategies = { Standard, External };
+const strategies = { Standard, External, HerokuWebHooks };
 
 export {
   PermissionLevelEnum,

--- a/api/src/auth/strategies/heroku_webhook/index.ts
+++ b/api/src/auth/strategies/heroku_webhook/index.ts
@@ -1,0 +1,13 @@
+import * as Hapi from '@hapi/hapi';
+import * as Boom from '@hapi/boom';
+
+const validateHerokuWebhook =
+  async (request: Hapi.Request, token: string, h: Hapi.ResponseToolkit) => {
+    const { server: { app: { config } } } = request;
+
+    return config.webhooks.heroku.secret === token
+    ? { isValid: true, credentials: { user: 'heroku' } }
+    : Boom.forbidden('Error with authentication for 3rd party clients');
+  };
+
+export default validateHerokuWebhook;

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -5,6 +5,7 @@ import * as Hapi from '@hapi/hapi';
 import * as qs from 'qs';
 import { Dictionary } from 'ramda';
 import v1 from './api/v1';
+import webhooks from './webhooks/v1';
 import setup from './setup';
 import { Config } from '../config/types';
 import Logger from './services/logger';
@@ -32,6 +33,10 @@ const init = async (config: Config): Promise<Hapi.Server> => {
     {
       plugin: v1,
       routes: { prefix: '/v1' },
+    },
+    {
+      plugin: webhooks,
+      routes: { prefix: '/webhooks/v1' },
     },
   ]);
 

--- a/api/src/services/email/dispatcher.ts
+++ b/api/src/services/email/dispatcher.ts
@@ -1,5 +1,5 @@
 import * as Postmark from 'postmark';
-import { EmailTemplate } from './templates';
+import { EmailTemplate, WebhookEmailTemplates } from './templates';
 import { Config } from '../../../config';
 
 
@@ -12,7 +12,7 @@ type Attachment = {
 type Email = {
   from: string,
   to: string,
-  templateId: EmailTemplate,
+  templateId: EmailTemplate | WebhookEmailTemplates,
   templateModel?: object,
   attachments?: Attachment[],
 };

--- a/api/src/services/email/dispatcher.ts
+++ b/api/src/services/email/dispatcher.ts
@@ -9,7 +9,7 @@ type Attachment = {
   contentType: string,
 };
 
-type Email = {
+export type Email = {
   from: string,
   to: string,
   templateId: EmailTemplate | WebhookEmailTemplates,

--- a/api/src/services/email/index.ts
+++ b/api/src/services/email/index.ts
@@ -1,4 +1,4 @@
-import EmailDispatcher from './dispatcher';
+import EmailDispatcher, { Email } from './dispatcher';
 import { EmailTemplate, Templates, WebhookEmailTemplates } from './templates';
 import { Config } from '../../../config';
 import { User, CommunityBusiness } from '../../models';
@@ -32,26 +32,15 @@ export type EmailService = {
 
 const webhooks: EmailService['webhooks'] = {
   async onHerokuStagingRelease (cfg, appName) {
-    await EmailDispatcher.sendBatch(cfg, [
-      {
-        from: cfg.email.fromAddress,
-        to: cfg.email.developers[0],
-        templateId: WebhookEmailTemplates.ON_HEROKU_RELEASE,
-        templateModel: {
-          app_name: appName,
-          product_name: 'Twine Platform',
-        },
+    await EmailDispatcher.sendBatch(cfg, cfg.email.developers.map((email) => ({
+      from: cfg.email.fromAddress,
+      to: email,
+      templateId: WebhookEmailTemplates.ON_HEROKU_RELEASE,
+      templateModel: {
+        app_name: appName,
+        product_name: 'Twine Platform',
       },
-      {
-        from: cfg.email.fromAddress,
-        to: cfg.email.developers[1],
-        templateId: WebhookEmailTemplates.ON_HEROKU_RELEASE,
-        templateModel: {
-          app_name: appName,
-          product_name: 'Twine Platform',
-        },
-      },
-    ]);
+    } as Email)));
   },
 };
 

--- a/api/src/services/email/templates.ts
+++ b/api/src/services/email/templates.ts
@@ -32,3 +32,7 @@ export const Templates = {
     }
   },
 };
+
+export enum WebhookEmailTemplates {
+  ON_HEROKU_RELEASE = 12904099,
+}

--- a/api/src/webhooks/v1/heroku/index.ts
+++ b/api/src/webhooks/v1/heroku/index.ts
@@ -1,0 +1,5 @@
+import onStagingRelease from './onStagingRelease';
+
+export default [
+  ...onStagingRelease,
+];

--- a/api/src/webhooks/v1/heroku/onStagingRelease.ts
+++ b/api/src/webhooks/v1/heroku/onStagingRelease.ts
@@ -1,0 +1,38 @@
+import * as Hapi from '@hapi/hapi';
+import * as Joi from '@hapi/joi';
+
+
+const routes = [
+
+  {
+    method: 'POST',
+    path: '/heroku/on-staging-release',
+    options: {
+      description: 'Sends email when heroku app releases to staging',
+      auth: {
+        strategy: 'herokuWebhook',
+      },
+      validate:
+      {
+        payload: {
+          data: {
+            app: Joi.object({
+              name: Joi.string(),
+            }),
+          },
+        },
+      },
+    },
+    handler: async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
+      const {
+        server: { app: { EmailService, config } },
+        payload,
+      } = request;
+
+      await EmailService.webhooks.onHerokuStagingRelease(config, (<any> payload).data.app.name);
+      return h.response().code(204);
+    },
+  },
+] as Hapi.ServerRoute[];
+
+export default routes;

--- a/api/src/webhooks/v1/index.ts
+++ b/api/src/webhooks/v1/index.ts
@@ -1,13 +1,8 @@
 /*
- * Twine API v1
+ * Twine Webhooks v1
  *
- * The API is written as a self-contained plugin. The API tries
- * to minimise its dependencies on other plugins, providing its
- * own authentication strategies, request lifecycle hooks, route
- * definitions, etc.
+ * To handle auxilary action to subscribed webhooks
  *
- * See also
- * - api.json
  */
 import * as Hapi from '@hapi/hapi';
 import heroku from './heroku';
@@ -18,7 +13,7 @@ export default {
   register: async (server: Hapi.Server) => {
 
     /*
-     * API Routes
+     * Routes
      */
 
     // Pre-process routes

--- a/api/src/webhooks/v1/index.ts
+++ b/api/src/webhooks/v1/index.ts
@@ -1,0 +1,32 @@
+/*
+ * Twine API v1
+ *
+ * The API is written as a self-contained plugin. The API tries
+ * to minimise its dependencies on other plugins, providing its
+ * own authentication strategies, request lifecycle hooks, route
+ * definitions, etc.
+ *
+ * See also
+ * - api.json
+ */
+import * as Hapi from '@hapi/hapi';
+import heroku from './heroku';
+
+
+export default {
+  name: 'Twine Webhooks v1',
+  register: async (server: Hapi.Server) => {
+
+    /*
+     * API Routes
+     */
+
+    // Pre-process routes
+    const routes = [
+      ...heroku,
+    ];
+
+    // Register routes
+    server.route(routes);
+  },
+};


### PR DESCRIPTION
relates #238 

### Changes
- add heroku strategy for authentication
- add webhook endpoint sending devs emails
- add devs emails to env var
- add template id for postmark
- NOTE: not tested as this is a dev facing action. Can test if wanted

### Testing Requirements
- not user facing test in production

### Release Requirements
- no release restrictions, deploy when ready

### Manual Deployment
- [ ] api

### Additional steps

- [ ] add webhooks to all staging apps
- [ ] add new envs to api staging on heroku