### PR TITLE
🚑 ignore invalid date-strings from synced logs

### DIFF
--- a/api/database/migrations/20190808_create_monitoring_for_ignoring_synced_logs.ts
+++ b/api/database/migrations/20190808_create_monitoring_for_ignoring_synced_logs.ts
@@ -1,0 +1,3 @@
+import { buildQueryFromFile } from '../utils';
+exports.up = buildQueryFromFile(__filename);
+exports.down = () => {};

--- a/api/database/migrations/sql/20190808_create_monitoring_for_ignoring_synced_logs.sql
+++ b/api/database/migrations/sql/20190808_create_monitoring_for_ignoring_synced_logs.sql
@@ -1,0 +1,19 @@
+/*
+ * Create monitoring table for ignoring synced logs
+ *
+ * See https://github.com/TwinePlatform/twine-monolith/issues/246
+ */
+
+CREATE TABLE invalid_synced_logs_monitoring (
+  invalid_synced_logs_monitoring_id SERIAL NOT NULL UNIQUE,
+  user_account_id                   INT NOT NULL,
+  organisation_id                   INT NOT NULL,
+  payload                           JSONB NOT NULL,
+  created_at                        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  modified_at                       TIMESTAMP WITH TIME ZONE,
+  deleted_at                        TIMESTAMP WITH TIME ZONE,
+
+  CONSTRAINT invalid_synced_logs_monitoring_pk                       PRIMARY KEY (invalid_synced_logs_monitoring_id),
+  CONSTRAINT invalid_synced_logs_monitoring_to_user_fk               FOREIGN KEY (user_account_id) REFERENCES user_account ON DELETE CASCADE,
+  CONSTRAINT invalid_synced_logs_monitoring_to_community_business_fk FOREIGN KEY (organisation_id) REFERENCES organisation ON DELETE CASCADE
+);

--- a/api/src/api/v1/community_businesses/__tests__/volunteer_logs.test.integration.ts
+++ b/api/src/api/v1/community_businesses/__tests__/volunteer_logs.test.integration.ts
@@ -643,7 +643,7 @@ describe('API /community-businesses/me/volunteer-logs', () => {
       }));
 
       expect(res.statusCode).toBe(200);
-      expect(res.result).toEqual({ result: null });
+      expect(res.result).toEqual({ result: { ignored: 0, synced: 1 } });
 
       const resLogs = await server.inject(injectCfg({
         method: 'GET',
@@ -675,7 +675,7 @@ describe('API /community-businesses/me/volunteer-logs', () => {
       }));
 
       expect(res.statusCode).toBe(200);
-      expect(res.result).toEqual({ result: null });
+      expect(res.result).toEqual({ result: { ignored: 0, synced: 3 } });
 
       const resLogs = await server.inject(injectCfg({
         method: 'GET',
@@ -707,7 +707,7 @@ describe('API /community-businesses/me/volunteer-logs', () => {
       }));
 
       expect(res.statusCode).toBe(200);
-      expect(res.result).toEqual({ result: null });
+      expect(res.result).toEqual({ result: { ignored: 0, synced: 3 } });
 
       const resLogs = await server.inject(injectCfg({
         method: 'GET',
@@ -737,7 +737,7 @@ describe('API /community-businesses/me/volunteer-logs', () => {
       }));
 
       expect(res.statusCode).toBe(200);
-      expect(res.result).toEqual({ result: null });
+      expect(res.result).toEqual({ result: { ignored: 0, synced: 0 } });
 
       const resLogs = await server.inject(injectCfg({
         method: 'GET',
@@ -773,7 +773,7 @@ describe('API /community-businesses/me/volunteer-logs', () => {
       }));
 
       expect(res.statusCode).toBe(200);
-      expect(res.result).toEqual({ result: null });
+      expect(res.result).toEqual({ result: { ignored: 0, synced: 1 } });
 
       const resCheck = await server.inject(injectCfg({
         method: 'GET',
@@ -812,7 +812,7 @@ describe('API /community-businesses/me/volunteer-logs', () => {
       }));
 
       expect(res.statusCode).toBe(200);
-      expect(res.result).toEqual({ result: null });
+      expect(res.result).toEqual({ result: { ignored: 0, synced: 1 } });
 
       const resCheck = await server.inject(injectCfg({
         method: 'GET',
@@ -845,7 +845,7 @@ describe('API /community-businesses/me/volunteer-logs', () => {
       }));
 
       expect(res.statusCode).toBe(200);
-      expect(res.result).toEqual({ result: null });
+      expect(res.result).toEqual({ result: { ignored: 0, synced: 3 } });
 
       const resLogs = await server.inject(injectCfg({
         method: 'GET',
@@ -879,7 +879,7 @@ describe('API /community-businesses/me/volunteer-logs', () => {
       expect(res.statusCode).toBe(403);
     });
 
-    test('ERROR - fails when trying to sync logs w/ identical "startedAt" in payload', async () => {
+    test('SUCCESS - ignores logs w/ identical "startedAt" in payload', async () => {
       const now = new Date().toISOString();
       const logs = [
         { activity: 'Office support', duration: { minutes: 20 }, startedAt: now },
@@ -893,19 +893,11 @@ describe('API /community-businesses/me/volunteer-logs', () => {
         payload: logs,
       }));
 
-      expect(res.statusCode).toBe(400);
-
-      const resLogs = await server.inject(injectCfg({
-        method: 'GET',
-        url: '/v1/users/volunteers/me/volunteer-logs',
-        credentials: volCreds,
-      }));
-
-      expect(resLogs.statusCode).toBe(200);
-      expect((<any> resLogs.result).result).toHaveLength(7);
+      expect(res.statusCode).toBe(200);
+      expect(res.result).toEqual({ result: { ignored: 2, synced: 0 } });
     });
 
-    test('ERROR - fails when trying to sync logs w/ same "startedAt" as existing log', async () => {
+    test('SUCCESS - ignores logs w/ same "startedAt" as existing log', async () => {
       const resLogs = await server.inject(injectCfg({
         method: 'GET',
         url: '/v1/users/volunteers/me/volunteer-logs',
@@ -928,7 +920,8 @@ describe('API /community-businesses/me/volunteer-logs', () => {
         payload: logs,
       }));
 
-      expect(res.statusCode).toBe(400);
+      expect(res.statusCode).toBe(200);
+      expect(res.result).toEqual({ result: { ignored: 1, synced: 0 } });
     });
 
     test('ERROR - fails when one user isn\'t a volunteer', async () => {
@@ -985,7 +978,7 @@ describe('API /community-businesses/me/volunteer-logs', () => {
       }));
 
       expect(res.statusCode).toBe(200);
-      expect(res.result).toEqual({ result: null });
+      expect(res.result).toEqual({ result: { ignored: 3, synced: 1 } });
 
       const dbLogs: any[] = await server.app.knex('volunteer_hours_log')
         .select('*')

--- a/api/src/api/v1/community_businesses/__tests__/volunteer_logs.test.integration.ts
+++ b/api/src/api/v1/community_businesses/__tests__/volunteer_logs.test.integration.ts
@@ -994,9 +994,18 @@ describe('API /community-businesses/me/volunteer-logs', () => {
           user_account_id: volCreds.user.user.id,
         });
 
+      const monitoring: any[] = await server.app.knex('invalid_synced_logs_monitoring').select('*');
+
       expect(dbLogs).toHaveLength(8);
-      expect(dbLogs.some((log) => log.started_at === '2019-07-05T13:03:22.000Z')).toBe(true);
-      expect(dbLogs.some((log) => log.started_at === '2019-07-01T03:13:02.000Z')).toBe(false);
+      expect(dbLogs.some((log) =>
+        log.started_at.toISOString().startsWith(`2019-${prev}-01`))).toBe(false);
+      expect(dbLogs.some((log) =>
+        log.started_at.toISOString().startsWith(`2019-${month}-05`))).toBe(true);
+
+      expect(monitoring).toHaveLength(1);
+      expect(monitoring[0].payload).toEqual(logs.map((log) => ({ ...log, userId: 'me' })));
+      expect(monitoring[0].user_account_id).toBe(volCreds.user.user.id);
+      expect(monitoring[0].organisation_id).toBe(volCreds.user.organisation.id);
     });
   });
 });

--- a/api/src/api/v1/community_businesses/__tests__/volunteer_logs.test.integration.ts
+++ b/api/src/api/v1/community_businesses/__tests__/volunteer_logs.test.integration.ts
@@ -996,7 +996,7 @@ describe('API /community-businesses/me/volunteer-logs', () => {
         log.started_at.toISOString().startsWith(`2019-${month}-05`))).toBe(true);
 
       expect(monitoring).toHaveLength(1);
-      expect(monitoring[0].payload).toEqual(logs.map((log) => ({ ...log, userId: 'me' })));
+      expect(monitoring[0].payload).toEqual(logs.slice(1).map((log) => ({ ...log, userId: 'me' })));
       expect(monitoring[0].user_account_id).toBe(volCreds.user.user.id);
       expect(monitoring[0].organisation_id).toBe(volCreds.user.organisation.id);
     });

--- a/api/src/api/v1/community_businesses/volunteer_logs.ts
+++ b/api/src/api/v1/community_businesses/volunteer_logs.ts
@@ -372,7 +372,7 @@ const routes: Hapi.ServerRoute[] = [
         // If some logs correspond to other users...
         payload.some((log) => log.userId !== 'me') &&
         // ...and we don't have permission to write to other users
-        !Scopes.has(['volunteer_logs-sibling:write', 'volunteer_logs-child:write'], scope)
+        !Scopes.intersect(['volunteer_logs-sibling:write', 'volunteer_logs-child:write'], scope)
       ) {
         // Then 403
         return Boom.forbidden('Insufficient scope: cannot write other users logs');

--- a/api/src/api/v1/community_businesses/volunteer_logs.ts
+++ b/api/src/api/v1/community_businesses/volunteer_logs.ts
@@ -30,8 +30,6 @@ import { requestQueryToModelQuery } from '../utils';
 import { query } from '../users/schema';
 import { Credentials as StandardCredentials } from '../../../auth/strategies/standard';
 import { RoleEnum } from '../../../models/types';
-import { PermissionLevelEnum } from '../../../auth';
-import { AccessEnum, ResourceEnum } from '../../../auth/types';
 
 
 const ignoreInvalidLogs = (logs: SyncMyVolunteerLogsRequest['payload']) => {

--- a/api/src/api/v1/community_businesses/volunteer_logs.ts
+++ b/api/src/api/v1/community_businesses/volunteer_logs.ts
@@ -318,7 +318,11 @@ const routes: Hapi.ServerRoute[] = [
       auth: {
         strategy: 'standard',
         access: {
-          scope: ['volunteer_logs-own:write', 'volunteer_logs-sibling:write'],
+          scope: [
+            'volunteer_logs-sibling:write',
+            'volunteer_logs-child:write',
+            'volunteer_logs-own:write',
+          ],
         },
       },
       validate: {

--- a/api/src/api/v1/community_businesses/volunteer_logs.ts
+++ b/api/src/api/v1/community_businesses/volunteer_logs.ts
@@ -446,7 +446,7 @@ const routes: Hapi.ServerRoute[] = [
               user,
               communityBusiness,
               { message: result.message, stack: result.stack, payload: payload[i] }
-            );
+            ).catch(() => {});
           } else {
             acc.synced = acc.synced + 1;
           }

--- a/api/src/api/v1/community_businesses/volunteer_logs.ts
+++ b/api/src/api/v1/community_businesses/volunteer_logs.ts
@@ -352,9 +352,21 @@ const routes: Hapi.ServerRoute[] = [
         payload: _payload,
       } = request;
 
-      const { user, scope } = StandardCredentials.fromRequest(request);
+      const { user, organisation, scope } = StandardCredentials.fromRequest(request);
 
       const payload = ignoreInvalidLogs(_payload);
+
+      if (payload.length !== _payload.length) {
+        // Do not await - this is an auxiliary action
+        knex('invalid_synced_logs_monitoring')
+          .insert({
+            payload: JSON.stringify(_payload),
+            user_account_id: user.id,
+            organisation_id: organisation.id,
+          })
+          .then(() => {})
+          .catch(() => {});
+      }
 
       if (
         payload.some((log) => log.userId !== 'me') && // If some logs correspond to other users

--- a/api/src/auth/scopes/__tests__/index.test.ts
+++ b/api/src/auth/scopes/__tests__/index.test.ts
@@ -1,0 +1,55 @@
+import * as Scopes from '..';
+const PermissionsData = require('../../../../database/data/seed/permissions.seed.json');
+
+
+describe('Scopes', () => {
+
+  describe('stringToScopes', () => {
+
+    PermissionsData.permissions.forEach((permission: string) => {
+
+      test(`${permission} is valid`, () => {
+        expect(Scopes.stringToScope(permission)).toEqual(expect.objectContaining({
+          access: expect.stringContaining(''),
+          resource: expect.stringContaining(''),
+          permissionLevel: expect.stringContaining(''),
+        }));
+      });
+
+    });
+
+  });
+
+  describe('intersect', () => {
+    test('both empty arrays return false', () => {
+      expect(Scopes.intersect([], [])).toBe(false);
+    });
+
+    test('left empty returns false', () => {
+      expect(Scopes.intersect([], PermissionsData.permissions)).toBe(false);
+    });
+
+    test('right empty returns false', () => {
+      expect(Scopes.intersect(PermissionsData.permissions, [])).toBe(false);
+    });
+
+    test('neither empty, no intersection returns false', () => {
+      expect(
+        Scopes.intersect(
+          PermissionsData.permissions.slice(0, 3),
+          PermissionsData.permissions.slice(3)
+        )
+      ).toBe(false);
+    });
+
+    test('neither empty, with intersection returns true', () => {
+      expect(
+        Scopes.intersect(
+          PermissionsData.permissions.slice(0, 5),
+          PermissionsData.permissions.slice(3)
+        )
+      ).toBe(true);
+    });
+  });
+
+});

--- a/api/src/auth/scopes/index.ts
+++ b/api/src/auth/scopes/index.ts
@@ -1,3 +1,4 @@
+import { intersection } from 'ramda';
 import { AccessEnum, ResourceEnum, PermissionLevelEnum } from '../types';
 
 export type Scope = {
@@ -6,5 +7,103 @@ export type Scope = {
   resource: ResourceEnum
 };
 
+const toResourceEnum = (s: string): ResourceEnum => {
+  switch (s) {
+    case ResourceEnum.CONSTANTS:
+      return ResourceEnum.CONSTANTS;
+
+    case ResourceEnum.ORG_DETAILS:
+      return ResourceEnum.ORG_DETAILS;
+
+    case ResourceEnum.ORG_FEEDBACK:
+      return ResourceEnum.ORG_FEEDBACK;
+
+    case ResourceEnum.ORG_INVITATIONS:
+      return ResourceEnum.ORG_INVITATIONS;
+
+    case ResourceEnum.ORG_OUTREACH:
+      return ResourceEnum.ORG_OUTREACH;
+
+    case ResourceEnum.ORG_SUBSCRIPTIONS:
+      return ResourceEnum.ORG_SUBSCRIPTIONS;
+
+    case ResourceEnum.ORG_TRAINING:
+      return ResourceEnum.ORG_TRAINING;
+
+    case ResourceEnum.ORG_VOLUNTEERS:
+      return ResourceEnum.USER_DETAILS;
+
+    case ResourceEnum.USER_DETAILS:
+      return ResourceEnum.USER_DETAILS;
+
+    case ResourceEnum.VISIT_ACTIVITIES:
+      return ResourceEnum.VISIT_ACTIVITIES;
+
+    case ResourceEnum.VISIT_LOGS:
+      return ResourceEnum.VISIT_LOGS;
+
+    case ResourceEnum.VOLUNTEER_LOGS:
+      return ResourceEnum.VOLUNTEER_LOGS;
+
+    default:
+      throw new Error(`Unrecognised resource: ${s}`);
+  }
+};
+
+const toAccessEnum = (s: string): AccessEnum => {
+  switch (s) {
+    case AccessEnum.DELETE:
+      return AccessEnum.DELETE;
+
+    case AccessEnum.READ:
+      return AccessEnum.READ;
+
+    case AccessEnum.WRITE:
+      return AccessEnum.WRITE;
+
+    default:
+      throw new Error(`Unrecognised access level: ${s}`);
+  }
+};
+
+const toPermissionLevelEnum = (s: string): PermissionLevelEnum => {
+  switch (s) {
+    case PermissionLevelEnum.ALL:
+      return PermissionLevelEnum.ALL;
+
+    case PermissionLevelEnum.CHILD:
+      return PermissionLevelEnum.CHILD;
+
+    case PermissionLevelEnum.OWN:
+      return PermissionLevelEnum.OWN;
+
+    case PermissionLevelEnum.PARENT:
+      return PermissionLevelEnum.PARENT;
+
+    case PermissionLevelEnum.SIBLING:
+      return PermissionLevelEnum.SIBLING;
+
+    default:
+      throw new Error(`Unrecognised permission level: ${s}`);
+  }
+};
+
 export const scopeToString = (s: Scope): string =>
   `${s.resource}-${s.permissionLevel}:${s.access}`;
+
+export const stringToScope = (s: string): Scope => {
+  const match = s.match(/(\w)\-(\w)\:(\w)/);
+
+  if (!match) {
+    throw new Error(`Not a valid scope: ${s}`);
+  }
+
+  return {
+    resource: toResourceEnum(match[0]),
+    access: toAccessEnum(match[1]),
+    permissionLevel: toPermissionLevelEnum(match[2]),
+  };
+};
+
+export const has = (left: string[], right: string[]) =>
+  intersection(left.map(stringToScope), right.map(stringToScope)).length > 0;

--- a/api/src/auth/scopes/index.ts
+++ b/api/src/auth/scopes/index.ts
@@ -92,18 +92,18 @@ export const scopeToString = (s: Scope): string =>
   `${s.resource}-${s.permissionLevel}:${s.access}`;
 
 export const stringToScope = (s: string): Scope => {
-  const match = s.match(/(\w)\-(\w)\:(\w)/);
+  const match = s.match(/(\w+)\-(\w+)\:(\w+)/);
 
   if (!match) {
     throw new Error(`Not a valid scope: ${s}`);
   }
 
   return {
-    resource: toResourceEnum(match[0]),
-    access: toAccessEnum(match[1]),
+    resource: toResourceEnum(match[1]),
     permissionLevel: toPermissionLevelEnum(match[2]),
+    access: toAccessEnum(match[3]),
   };
 };
 
-export const has = (left: string[], right: string[]) =>
+export const intersect = (left: string[], right: string[]) =>
   intersection(left.map(stringToScope), right.map(stringToScope)).length > 0;

--- a/api/src/models/types.ts
+++ b/api/src/models/types.ts
@@ -398,17 +398,22 @@ export type CommunityBusinessCollection = Collection<CommunityBusiness> & {
 
 export type VolunteerLogCollection = Collection<VolunteerLog> & {
   fromUser: (
-      k: Knex,
-      u: User,
-      q?: ModelQuery<VolunteerLog>) => Promise<VolunteerLog[]>
+    k: Knex,
+    u: User,
+    q?: ModelQuery<VolunteerLog>) => Promise<VolunteerLog[]>
   fromCommunityBusiness: (
-      k: Knex,
-      c: CommunityBusiness,
-      q?: ModelQuery<VolunteerLog>) => Promise<VolunteerLog[]>
+    k: Knex,
+    c: CommunityBusiness,
+    q?: ModelQuery<VolunteerLog>) => Promise<VolunteerLog[]>
   fromUserAtCommunityBusiness: (
-      k: Knex,
-      u: User, c: CommunityBusiness,
-      q?: ModelQuery<VolunteerLog>) => Promise<VolunteerLog[]>
+    k: Knex,
+    u: User, c: CommunityBusiness,
+    q?: ModelQuery<VolunteerLog>) => Promise<VolunteerLog[]>
+  recordInvalidLog: (
+    k: Knex,
+    u: User,
+    c: CommunityBusiness,
+    payload: object) => Promise<void>
   getProjects: (
     k: Knex,
     c: CommunityBusiness) => Promise<VolunteerProject[]>

--- a/api/src/models/volunteer_log.ts
+++ b/api/src/models/volunteer_log.ts
@@ -240,6 +240,15 @@ export const VolunteerLogs: VolunteerLogCollection = {
     });
   },
 
+  async recordInvalidLog (client, user, organisation, payload) {
+    return client('invalid_synced_logs_monitoring')
+      .insert({
+        payload: JSON.stringify(payload),
+        user_account_id: user.id,
+        organisation_id: organisation.id,
+      });
+  },
+
   async serialise (log) {
     return log;
   },

--- a/lib/twine-util/__tests__/promises.test.ts
+++ b/lib/twine-util/__tests__/promises.test.ts
@@ -107,4 +107,39 @@ describe('Utilities :: Promises', () => {
       expect(x).toBe(2);
     });
   });
+
+  describe('some', () => {
+    test('All promises resolve', async () => {
+      const ps = [1, 2, 3, 4].map((n) => Promise.resolve(n));
+
+      const results = await Promises.some(ps);
+
+      expect(results).toHaveLength(ps.length);
+      expect(results).toEqual([1, 2, 3, 4]);
+    });
+
+    test('Some promises resolve', async () => {
+      const ps = [1, 2, 3, 4].map((n) => n % 2 ? Promise.resolve(n) : Promise.reject(new Error('nope')));
+
+      const results = await Promises.some(ps);
+
+      expect(results).toHaveLength(ps.length);
+      expect(results[0]).toEqual(1);
+      expect(results[1].message).toEqual('nope');
+      expect(results[2]).toEqual(3);
+      expect(results[3].message).toEqual('nope');
+    });
+
+    test('All promises reject', async () => {
+      const ps = [1, 2, 3, 4].map((n) => Promise.reject(new Error('nope')));
+
+      const results = await Promises.some(ps);
+
+      expect(results).toHaveLength(ps.length);
+      results.forEach((result) => {
+        expect(result).toBeInstanceOf(Error);
+        expect(result.message).toEqual('nope');
+      });
+    });
+  });
 });

--- a/lib/twine-util/promises.ts
+++ b/lib/twine-util/promises.ts
@@ -29,3 +29,7 @@ export const find = async <T>(fn: (a: T) => Promise<boolean>, xs: T[]): Promise<
     ? head
     : find(fn, tail);
 };
+
+export const some = async <T>(ps: Promise<T>[]) => {
+  return Promise.all(ps.map((p) => p.catch((error) => error)));
+};

--- a/volunteer-app/www/js/app.js
+++ b/volunteer-app/www/js/app.js
@@ -33,7 +33,7 @@
 			$rootScope.options = {
 				appName: 'Twine',
 				debug: false,
-				environment: 'dev',	// dev | stage | live
+				environment: 'live',	// dev | stage | live
 				apiBaseUrl: {
 					local: 'http://localhost:4000/v1/',
 					dev:   'http://localhost:4000/v1/',

--- a/volunteer-app/www/js/app.js
+++ b/volunteer-app/www/js/app.js
@@ -193,7 +193,7 @@
 						logsData.logs = logsData.logs.map(function (log) {
 							return {
 								id: log.id || undefined,
-								userId: log.user_id === userId ? undefined : log.user_id,
+								userId: log.userId === userId ? undefined : log.userId,
 								duration: typeof log.duration === 'number' ? { minutes: log.duration } : log.duration,
 								activity: log.activity,
 								startedAt: log.date_of_log,

--- a/volunteer-app/www/js/app.js
+++ b/volunteer-app/www/js/app.js
@@ -33,7 +33,7 @@
 			$rootScope.options = {
 				appName: 'Twine',
 				debug: false,
-				environment: 'live',	// dev | stage | live
+				environment: 'dev',	// dev | stage | live
 				apiBaseUrl: {
 					local: 'http://localhost:4000/v1/',
 					dev:   'http://localhost:4000/v1/',
@@ -193,7 +193,7 @@
 						logsData.logs = logsData.logs.map(function (log) {
 							return {
 								id: log.id || undefined,
-								userId: log.userId === userId ? undefined : log.userId,
+								userId: log.user_id === userId ? undefined : log.user_id,
 								duration: typeof log.duration === 'number' ? { minutes: log.duration } : log.duration,
 								activity: log.activity,
 								startedAt: log.date_of_log,


### PR DESCRIPTION
related to #246 

### Changes
- Mainly an attempt to prevent this endpoint from returning non-200 status codes where reasonable to avoid users of the volunteer app being trapped in offline mode ☹️
- re-implement the temporary fix in #245 
  - allow logs with invalid timestamps for `startedAt` and `deletedAt` through validation but ignore them when actually syncing
- Remove sync operation from transaction: if only some logs can be synced, they should be, others ignored
- Endpoint responds with `{ synced: Number, ignored: Number }` to avoid transaction problems in tests
- Ignored logs are stored as JSON blobs in temporary table `invalid_synced_logs_monitoring`.
- Add some `Scopes` utility functions (with a little added validation)
- Add a `Promises.some` utility function: like `Promise.all` but resolves no matter what and stores the error objects of each rejected promise.

### Testing Requirements
- [x] Volunteer app
  - With changes:
    - Use web-interface
    - Using the dev tools, disable network
    - Add more than one log (app should go into offline mode)
    - Using dev tools, manually edit the offline cache (local storage) to corrupt one of the logs' timestamps
    - Re-enable network, then try to sync logs
    - Expect app to leave offline mode and successfully sync stored logs, except for corrupted log, which should be ignored.
  - Without changes:
    - Steps as above, but app should be unable to leave offline mode

### Release Requirements
Release informally agreed at planning meeting (5/8/19)

### Manual Deployment
- API
