### PR TITLE
🐛 fix default redis url for dev env

### DIFF
--- a/api/config/config.development.ts
+++ b/api/config/config.development.ts
@@ -43,7 +43,7 @@ const config: DeepPartial<Config> = {
   cache: {
     session: {
       name: 'session',
-      options: { url: envOr('REDIS_URL_DEVELOPMENT', 'redis://localhost:6379 ') },
+      options: { url: envOr('REDIS_URL_DEVELOPMENT', 'redis://localhost:6379') },
     },
   },
 };


### PR DESCRIPTION
### Changes
- remove space in default redis url