### PR TITLE
🚸 add overlay to graph page when no legend items selected

### DIFF
--- a/dashboard-app/src/features/dashboard/ByTime/TimeTabs.tsx
+++ b/dashboard-app/src/features/dashboard/ByTime/TimeTabs.tsx
@@ -56,6 +56,7 @@ const TimeTabs: FunctionComponent<Props> = (props) => {
                 unit={unit}
                 xAxisTitle={'Months'}
                 yAxisTitle={`Volunteer ${unit}`}
+                defaultSelection={true}
               />
             )
           }

--- a/dashboard-app/src/features/dashboard/ByVolunteer/VolunteerTabs.tsx
+++ b/dashboard-app/src/features/dashboard/ByVolunteer/VolunteerTabs.tsx
@@ -12,10 +12,10 @@ import { LegendData } from '../components/StackedBarChart/types';
 import { TitleString } from '../components/Title';
 import { Orderable } from '../hooks/useOrderable';
 
+
 /*
  * Types
  */
-
 interface Props {
   data?: AggregatedData;
   unit: DurationUnitEnum;
@@ -27,12 +27,14 @@ interface Props {
   setLegendData: React.Dispatch<React.SetStateAction<LegendData>>;
 }
 
+
 /*
  * Styles
  */
 const DataTable = styled(_DataTable)`
   margin-top: 4rem;
 `;
+
 
 /*
  * Component
@@ -49,7 +51,7 @@ const VolunteerTabs: FunctionComponent<Props> = (props) => {
     orderable,
   } = props;
 
-  return(
+  return (
     <Row center="xs">
       <Col xs={12}>
         <TabGroup titles={['Chart', 'Table']}>
@@ -85,4 +87,3 @@ const VolunteerTabs: FunctionComponent<Props> = (props) => {
 };
 
 export default VolunteerTabs;
-

--- a/dashboard-app/src/features/dashboard/ByVolunteer/VolunteerTabs.tsx
+++ b/dashboard-app/src/features/dashboard/ByVolunteer/VolunteerTabs.tsx
@@ -65,6 +65,7 @@ const VolunteerTabs: FunctionComponent<Props> = (props) => {
                 unit={unit}
                 xAxisTitle={'Months'}
                 yAxisTitle={`Volunteer ${unit}`}
+                defaultSelection={false}
               />
             )
           }

--- a/dashboard-app/src/features/dashboard/components/StackedBarChart/Chart.tsx
+++ b/dashboard-app/src/features/dashboard/components/StackedBarChart/Chart.tsx
@@ -9,7 +9,6 @@ import RoundedBar from './RoundedBar';
 import { getStackedGraphOptions, totalizer } from './utils/chartjsUtils';
 import _Card from '../../../../lib/ui/components/Card';
 import { ColoursEnum } from '../../../../lib/ui/design_system';
-import { FullWidthTextBox } from '../../../../lib/ui/components/FullWidthTextBox';
 import { TitleString, Title } from '../Title';
 
 
@@ -26,9 +25,6 @@ interface Props {
   tooltipUnit: string;
 }
 
-type HidableTextBoxProp = {
-  isVisible: boolean;
-};
 
 /*
  * Styles
@@ -38,9 +34,21 @@ const Card = styled(_Card)`
   height: 100%;
 `;
 
-const HidableTextBox = styled(FullWidthTextBox)<HidableTextBoxProp>`
-  visibility: ${({ isVisible }) => isVisible ? 'inherit' : 'hidden'};
+const GraphContentContainer = styled.div`
+  position: relative;
 `;
+
+const HideableTextOverlay = styled.div<{ isVisible: boolean }>`
+  position: absolute;
+  background-color: white;
+  opacity: ${(props) => props.isVisible ? 1 : 0};
+  transition: opacity 0.2s linear;
+  display: block;
+  height: 100%;
+  width: 100%;
+  padding: 10rem;
+`;
+
 
 /*
  * Helpers
@@ -64,30 +72,22 @@ const Chart: FunctionComponent<Props> = (props) => {
     tooltipUnit,
   } = props;
 
-  const graph = (
-    <RoundedBar
-      datasetKeyProvider={datasetKeyProvider}
-      plugins={[totalizer, ChartDataLabels]}
-      data={data}
-      options={getStackedGraphOptions(xAxisTitle, yAxisTitle, tooltipUnit)}
-    />
-  );
-
   return (
     <Card>
       <Title title={title}/>
       <Row center="xs" middle="xs">
         <Col xs={12} md={9}>
-        <HidableTextBox
-          height="2rem"
-          isVisible={isAllLegendDataInactive}
-          text ={noActiveLegendText}
-        />
-          {
-            checkIsDataEmpty(data)
-              ? <FullWidthTextBox text ="NO DATA AVAILABLE"/>
-              : graph
-          }
+          <GraphContentContainer>
+            <HideableTextOverlay isVisible={checkIsDataEmpty(data) || isAllLegendDataInactive}>
+              {noActiveLegendText}
+            </HideableTextOverlay>
+            <RoundedBar
+              datasetKeyProvider={datasetKeyProvider}
+              plugins={[totalizer, ChartDataLabels]}
+              data={data}
+              options={getStackedGraphOptions(xAxisTitle, yAxisTitle, tooltipUnit)}
+            />
+          </GraphContentContainer>
         </Col>
       </Row>
     </Card>

--- a/dashboard-app/src/features/dashboard/components/StackedBarChart/Chart.tsx
+++ b/dashboard-app/src/features/dashboard/components/StackedBarChart/Chart.tsx
@@ -8,8 +8,9 @@ import * as chartjs from 'chart.js';
 import RoundedBar from './RoundedBar';
 import { getStackedGraphOptions, totalizer } from './utils/chartjsUtils';
 import _Card from '../../../../lib/ui/components/Card';
-import { ColoursEnum } from '../../../../lib/ui/design_system';
+import { ColoursEnum, MediaQueriesEnum } from '../../../../lib/ui/design_system';
 import { TitleString, Title } from '../Title';
+import { Paragraph } from '../../../../lib/ui/components/Typography';
 
 
 /*
@@ -46,16 +47,25 @@ const HideableTextOverlay = styled.div<{ isVisible: boolean }>`
   display: block;
   height: 100%;
   width: 100%;
-  padding: 10rem;
+  padding: 10rem 0;
+
+  ${MediaQueriesEnum.landscapeTablet} {
+    padding: 8rem 0;
+  };
 `;
 
+const TransitionText = styled(Paragraph)<{ isVisible: boolean }>`
+  opacity: ${(props) => props.isVisible ? 1 : 0};
+  transition: opacity 0.1s linear;
+  transition-delay: 0.1s;
+`;
 
 /*
  * Helpers
  */
+
 const datasetKeyProvider = (d: { id: number }) => d.id;
 const checkIsDataEmpty = (cd: any) => (!cd || cd.datasets.length === 0);
-
 
 /*
  * Components
@@ -72,14 +82,16 @@ const Chart: FunctionComponent<Props> = (props) => {
     tooltipUnit,
   } = props;
 
+  const isVisible = checkIsDataEmpty(data) || isAllLegendDataInactive;
+
   return (
     <Card>
       <Title title={title}/>
       <Row center="xs" middle="xs">
         <Col xs={12} md={9}>
           <GraphContentContainer>
-            <HideableTextOverlay isVisible={checkIsDataEmpty(data) || isAllLegendDataInactive}>
-              {noActiveLegendText}
+            <HideableTextOverlay isVisible={isVisible}>
+              <TransitionText isVisible={isVisible}>{noActiveLegendText}</TransitionText >
             </HideableTextOverlay>
             <RoundedBar
               datasetKeyProvider={datasetKeyProvider}

--- a/dashboard-app/src/features/dashboard/components/StackedBarChart/index.tsx
+++ b/dashboard-app/src/features/dashboard/components/StackedBarChart/index.tsx
@@ -28,6 +28,7 @@ interface Props {
   title: TitleString;
   legendData: LegendData;
   setLegendData: React.Dispatch<React.SetStateAction<LegendData>>;
+  defaultSelection: boolean;
 }
 
 /*
@@ -35,7 +36,7 @@ interface Props {
  */
 
 const StackedBarChart: FunctionComponent<Props> = (props) => {
-  const { data, xAxisTitle, yAxisTitle, title, unit, legendData, setLegendData } = props;
+  const { data, xAxisTitle, yAxisTitle, title, unit, legendData, setLegendData, defaultSelection } = props;
   const [chartData, setChartData] = useState();
   const [tooltipUnit, setTooltipUnit] = useState('');
 
@@ -52,7 +53,7 @@ const StackedBarChart: FunctionComponent<Props> = (props) => {
   }, [legendData]);
 
   useEffect(() => {
-    const newLegendData = updateLegendData(data, legendData);
+    const newLegendData = updateLegendData(data, legendData, defaultSelection);
     const zeroedOutData = sortAndZeroOutInactiveData(data, newLegendData);
     setLegendData(newLegendData);
     setChartData(aggregatedToStackedGraph(zeroedOutData, unit));
@@ -86,6 +87,7 @@ const StackedBarChart: FunctionComponent<Props> = (props) => {
     setLegendActivityOfAll,
     setLegendActivityOnUpdate,
     title: data.groupByX,
+    defaultSelection
   };
 
   return (

--- a/dashboard-app/src/features/dashboard/components/StackedBarChart/index.tsx
+++ b/dashboard-app/src/features/dashboard/components/StackedBarChart/index.tsx
@@ -64,11 +64,8 @@ const StackedBarChart: FunctionComponent<Props> = (props) => {
   }, [legendData]);
 
   useEffect(() => {
-    const newValue = unit === DurationUnitEnum.DAYS
-          ? 'days'
-          : 'hrs';
-    setTooltipUnit(newValue);
-  });
+    setTooltipUnit(unit === DurationUnitEnum.DAYS ? 'days' : 'hrs');
+  }, [unit]);
 
   const noActiveLegendText = data.groupByX === 'Activity'
     ? 'Select an activity to show data'

--- a/dashboard-app/src/features/dashboard/components/StackedBarChart/utils/__tests__/index.test.ts
+++ b/dashboard-app/src/features/dashboard/components/StackedBarChart/utils/__tests__/index.test.ts
@@ -115,8 +115,8 @@ describe('Helpers', () => {
         ]} as AggregatedData;
       const expected = createLegendData(aggregatedData);
       expect(expected).toEqual([
-        { active: true, name: 'Aku Aku', id: 2 },
-        { active: true, name: 'Crash Bandicoot', id: 3 },
+        { active: false, name: 'Aku Aku', id: 2 },
+        { active: false, name: 'Crash Bandicoot', id: 3 },
       ]);
     });
     test('Success :: Only creates items for users there is data for', async () => {
@@ -130,8 +130,8 @@ describe('Helpers', () => {
 
       const expected = createLegendData(aggregatedData);
       expect(expected).toEqual([
-        { active: true, name: 'Aku Aku', id: 2 },
-        { active: true, name: 'Crash Bandicoot', id: 3 },
+        { active: false, name: 'Aku Aku', id: 2 },
+        { active: false, name: 'Crash Bandicoot', id: 3 },
       ]);
     });
   });

--- a/dashboard-app/src/features/dashboard/components/StackedBarChart/utils/__tests__/index.test.ts
+++ b/dashboard-app/src/features/dashboard/components/StackedBarChart/utils/__tests__/index.test.ts
@@ -113,12 +113,28 @@ describe('Helpers', () => {
             { 'Outdoor and practical work': { minutes: 2 }, name: 'Aku Aku', id: 2 },
             { 'Outdoor and practical work': { hours: 4, minutes: 23 }, name: 'Crash Bandicoot', id: 3 },
         ]} as AggregatedData;
-      const expected = createLegendData(aggregatedData);
+      const expected = createLegendData(aggregatedData, true);
+      expect(expected).toEqual([
+        { active: true, name: 'Aku Aku', id: 2 },
+        { active: true, name: 'Crash Bandicoot', id: 3 },
+      ]);
+    });
+
+    test('Success :: creates a list of deselected active data', async () => {
+      const aggregatedData = {
+        groupByX: 'Volunteer Name',
+        groupByY: 'Activity',
+        rows: [
+            { 'Outdoor and practical work': { minutes: 2 }, name: 'Aku Aku', id: 2 },
+            { 'Outdoor and practical work': { hours: 4, minutes: 23 }, name: 'Crash Bandicoot', id: 3 },
+        ]} as AggregatedData;
+      const expected = createLegendData(aggregatedData, false);
       expect(expected).toEqual([
         { active: false, name: 'Aku Aku', id: 2 },
         { active: false, name: 'Crash Bandicoot', id: 3 },
       ]);
     });
+
     test('Success :: Only creates items for users there is data for', async () => {
       const aggregatedData = {
         groupByX: 'Volunteer Name',
@@ -128,10 +144,10 @@ describe('Helpers', () => {
             { 'Outdoor and practical work': { hours: 4, minutes: 23 }, name: 'Crash Bandicoot', id: 3 },
         ]} as AggregatedData;
 
-      const expected = createLegendData(aggregatedData);
+      const expected = createLegendData(aggregatedData, true);
       expect(expected).toEqual([
-        { active: false, name: 'Aku Aku', id: 2 },
-        { active: false, name: 'Crash Bandicoot', id: 3 },
+        { active: true, name: 'Aku Aku', id: 2 },
+        { active: true, name: 'Crash Bandicoot', id: 3 },
       ]);
     });
   });
@@ -158,7 +174,7 @@ describe('Helpers', () => {
           id: 3,
         },
       ];
-      const expected = updateLegendData(aggregatedData, oldActiveData);
+      const expected = updateLegendData(aggregatedData, oldActiveData, false);
       expect(expected).toEqual([
         { active: true, name: 'Aku Aku', id: 2 },
         { active: false, name: 'Crash Bandicoot', id: 3 },

--- a/dashboard-app/src/features/dashboard/components/StackedBarChart/utils/util.ts
+++ b/dashboard-app/src/features/dashboard/components/StackedBarChart/utils/util.ts
@@ -8,7 +8,7 @@ import { LegendData, LegendDatum } from '../types';
 export const sortByNameCaseInsensitive = sortBy(pipe(prop('name'), toLower));
 
 export const createLegendData =
-  (data: AggregatedData, defaultSelection: boolean) => {
+  (data: AggregatedData, defaultSelection: boolean): LegendData => {
     const visibleData = data.rows
       .map((row) => ({ id: row.id, name: row.name, active: defaultSelection } as LegendDatum));
 
@@ -16,7 +16,7 @@ export const createLegendData =
   };
 
 export const updateLegendData =
-  (data: AggregatedData, oldActiveData: LegendData, defaultSelection: boolean) => {
+  (data: AggregatedData, oldActiveData: LegendData, defaultSelection: boolean): LegendData => {
     const visibleData = createLegendData(data, defaultSelection);
 
     const newLegendData = visibleData.map((newItem) =>
@@ -43,13 +43,13 @@ export const sortAndZeroOutInactiveData = (data: AggregatedData, legendData: Leg
 }, data) as AggregatedData;
 
 
-export const isEveryDatumActive = (data: LegendData) =>
+export const isEveryDatumActive = (data: LegendData): boolean =>
   data.every((datum) => datum.active);
 
-export const isEveryDatumInactive = (data: LegendData) =>
+export const isEveryDatumInactive = (data: LegendData): boolean =>
   data.every((datum) => !datum.active);
 
-export const flipActiveOfAll = (data: LegendData) => {
+export const flipActiveOfAll = (data: LegendData): LegendData => {
   const active: boolean = isEveryDatumActive(data)
     ? false
     : isEveryDatumInactive(data);

--- a/dashboard-app/src/features/dashboard/components/StackedBarChart/utils/util.ts
+++ b/dashboard-app/src/features/dashboard/components/StackedBarChart/utils/util.ts
@@ -1,5 +1,3 @@
-
-
 import { sortBy, pipe, prop, toLower, omit, evolve } from 'ramda';
 import {
   AggregatedData,
@@ -10,15 +8,15 @@ import { LegendData, LegendDatum } from '../types';
 export const sortByNameCaseInsensitive = sortBy(pipe(prop('name'), toLower));
 
 export const createLegendData =
-  (data: AggregatedData): LegendData => {
+  (data: AggregatedData) => {
     const visibleData = data.rows
-      .map((row) => ({ id: row.id, name: row.name, active: true } as LegendDatum));
+      .map((row) => ({ id: row.id, name: row.name, active: false } as LegendDatum));
 
     return sortByNameCaseInsensitive(visibleData);
   };
 
 export const updateLegendData =
-  (data: AggregatedData, oldActiveData: LegendData): LegendData => {
+  (data: AggregatedData, oldActiveData: LegendData) => {
     const visibleData = createLegendData(data);
 
     const newLegendData = visibleData.map((newItem) =>
@@ -35,9 +33,9 @@ const zeroOutInactiveData = (legendData: LegendData) => (rows: Row[]) =>
       const matchingLegendData = legendData.find((data) => data.id === row.id);
       if (!matchingLegendData) return row;
       return matchingLegendData.active
-    ? row
-    : getYHeaderList(row).reduce((acc: object, el) => ({ ...acc, [el]: 0 }),
-      { id: row.id, name: row.name });
+        ? row
+        : getYHeaderList(row)
+            .reduce((acc: object, el) => ({ ...acc, [el]: 0 }), { id: row.id, name: row.name });
     });
 
 export const sortAndZeroOutInactiveData = (data: AggregatedData, legendData: LegendData) => evolve({
@@ -45,16 +43,16 @@ export const sortAndZeroOutInactiveData = (data: AggregatedData, legendData: Leg
 }, data) as AggregatedData;
 
 
-export const isEveryDatumActive = (data: LegendData): boolean =>
+export const isEveryDatumActive = (data: LegendData) =>
   data.every((datum) => datum.active);
 
-export const isEveryDatumInactive = (data: LegendData): boolean =>
+export const isEveryDatumInactive = (data: LegendData) =>
   data.every((datum) => !datum.active);
 
-export const flipActiveOfAll = (data: LegendData): LegendData => {
+export const flipActiveOfAll = (data: LegendData) => {
   const active: boolean = isEveryDatumActive(data)
     ? false
     : isEveryDatumInactive(data);
 
-  return data.map((x) => ({ ...x, active }));
+  return data.map<LegendDatum>((x) => ({ ...x, active }));
 };

--- a/dashboard-app/src/features/dashboard/components/StackedBarChart/utils/util.ts
+++ b/dashboard-app/src/features/dashboard/components/StackedBarChart/utils/util.ts
@@ -8,16 +8,16 @@ import { LegendData, LegendDatum } from '../types';
 export const sortByNameCaseInsensitive = sortBy(pipe(prop('name'), toLower));
 
 export const createLegendData =
-  (data: AggregatedData) => {
+  (data: AggregatedData, defaultSelection: boolean) => {
     const visibleData = data.rows
-      .map((row) => ({ id: row.id, name: row.name, active: false } as LegendDatum));
+      .map((row) => ({ id: row.id, name: row.name, active: defaultSelection } as LegendDatum));
 
     return sortByNameCaseInsensitive(visibleData);
   };
 
 export const updateLegendData =
-  (data: AggregatedData, oldActiveData: LegendData) => {
-    const visibleData = createLegendData(data);
+  (data: AggregatedData, oldActiveData: LegendData, defaultSelection: boolean) => {
+    const visibleData = createLegendData(data, defaultSelection);
 
     const newLegendData = visibleData.map((newItem) =>
       oldActiveData.find((oldItem) => newItem.id === oldItem.id) || newItem


### PR DESCRIPTION
fixes #239 

### Changes
- selection of legend items is configurable
- Add text overlay when legend items are disabled

### Testing Requirements
- [x] Dashboard
  - Login
  - Navigate to "/time"
    - Expect all legend items to be de-selected
    - Expect to see message "Select an activity to show data"
    - Expect chart not to be displayed
  - Select any number of activities from the legend
    - Expect chart to be displayed
    - Expect previously displayed message to disappear
  - Navigate to "/volunteers"
    - Expect all legend items to be de-selected
    - Expect to see message "Select a volunteer to show their hours"
    - Expect chart not to be displayed
  - Select any number of volunteers from the legend
    - Expect chart to be displayed
    - Expect previously displayed message to disappear

### Release Requirements
- review by PO then release, no comms

### Manual Deployment
- [ ] Dashboard