### PR TITLE
🔧 travis/code-climate fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
         - lerna run cover
 
 after_success:
-  - bash ./.travis/cc-report.sh
+  - bash $TRAVIS_BUILD_DIR/.travis/cc-report.sh
 
 notifications:
   email:

--- a/.travis/cc-download.sh
+++ b/.travis/cc-download.sh
@@ -6,13 +6,13 @@ PLATFORM=$(uname -s)
 
 if [ $PLATFORM == "Darwin" ]; then
 
-  curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-darwin-amd64 > ./cc-test-reporter
-  chmod +x ./cc-test-reporter
+  curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-darwin-amd64 > $(dirname $0)/cc-test-reporter
+  chmod +x $(dirname $0)/cc-test-reporter
 
 elif [ $PLATFORM == 'Linux' ]; then
 
-  curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  chmod +x ./cc-test-reporter
+  curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > $(dirname $0)/cc-test-reporter
+  chmod +x $(dirname $0)/cc-test-reporter
 
 else
 

--- a/.travis/cc-report.sh
+++ b/.travis/cc-report.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ ! -f ./cc-test-reporter ]; then
+if [ ! -f $(dirname $0)/cc-test-reporter ]; then
   echo "No test reporter found";
   exit 1;
 fi
@@ -14,7 +14,7 @@ function format_lcov () {
   for f in $@; do
     if [ -f $1 ]; then
       echo "Formatting $f";
-      ./cc-test-reporter format-coverage -t lcov -o coverage/coverage.${1//\//-}.json $1;
+      $(dirname $0)/cc-test-reporter format-coverage -t lcov -o coverage/coverage.${1//\//-}.json $1;
     fi
   done
 }
@@ -23,7 +23,7 @@ files=$(find . -name 'lcov.info' -type f -not -path "*/node_modules/*")
 format_lcov ${files[@]}
 
 echo "Summing coverage reports"
-./cc-test-reporter sum-coverage -o coverage/coverage.total.json coverage/coverage.*.json;
+$(dirname $0)/cc-test-reporter sum-coverage -o coverage/coverage.total.json coverage/coverage.*.json;
 
 echo "Uploading overall coverage report"
-./cc-test-reporter upload-coverage -i coverage/coverage.total.json;
+$(dirname $0)/cc-test-reporter upload-coverage -i coverage/coverage.total.json;


### PR DESCRIPTION
fixes #276

### Changes
- Use absolute paths using `dirname` function instead of relying on `.`

### Testing Requirements
- [ ] Travis / Github
  - Check that code-coverage reports have been uploaded

### Release Requirements
N/A

### Manual Deployment
N/A