### PR TITLE
🔧 parallelise tests and only use one build stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,12 @@ install:
 
 jobs:
   include:
-    - stage: Build
-      script:
-        - lerna run lint
-        - lerna run build
-    - stage: Test
+    - stage: Build & Test
       before_script:
         - psql -U postgres -c 'create database twine_api_test'
         - psql -U postgres -c 'create extension postgis'
       script:
+        - lerna run lint
         - lerna run build
         - lerna run checks
         - lerna run cover

--- a/api/package.json
+++ b/api/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/TwinePlatform/twine-api#readme",
   "scripts": {
     "test:unit": "NODE_ENV=testing jest --config=jest.unit.config.js",
-    "test:integration": "NODE_ENV=testing jest --config=jest.integration.config.js --runInBand",
+    "test:integration": "NODE_ENV=testing jest --config=jest.integration.config.js",
     "test": "npm run test:unit && npm run test:integration",
     "cover:unit": "npm run test:unit -- --coverage",
     "cover:integration": "npm run test:integration -- --coverage",


### PR DESCRIPTION
20 minute builds is a bit too long

### Changes
- Parallelise integration tests; they use transactions, so all database changes are isolated
- Only use one build stage

### Testing Requirements
N/A

### Release Requirements
N/A

### Manual Deployment
N/A