### PR TITLE
🔍 add required postcode for visitors registration

### DIFF
--- a/api/src/api/v1/community_businesses/temporary/__tests__/delete.test.integration.ts
+++ b/api/src/api/v1/community_businesses/temporary/__tests__/delete.test.integration.ts
@@ -95,6 +95,7 @@ describe('DELETE /community-businesses/temporary/:id', () => {
         gender: 'male',
         birthYear: 1988,
         email: 'cstrife@soldier.com',
+        postCode: 'NB3 0LL',
       },
       credentials: tempCredentials,
     }));
@@ -139,6 +140,7 @@ describe('DELETE /community-businesses/temporary/:id', () => {
         birthYear: 1988,
         email: 'yuff@thethief.com',
         password: 'I<3daggers',
+        postCode: 'L3 3TT',
         role: RoleEnum.VOLUNTEER,
       },
       credentials: tempCredentials,

--- a/api/src/api/v1/community_businesses/visitors/__tests__/get.test.integration.ts
+++ b/api/src/api/v1/community_businesses/visitors/__tests__/get.test.integration.ts
@@ -8,7 +8,7 @@ import { ExternalCredentials, name as ExtName } from '../../../../../auth/strate
 import { injectCfg } from '../../../../../../tests/utils/inject';
 
 
-describe('API /community-businesses/{id}/visitors', () => {
+describe('API', () => {
   let server: Hapi.Server;
   let knex: Knex;
   let user: User;

--- a/api/src/api/v1/community_businesses/visitors/__tests__/put.test.integration.ts
+++ b/api/src/api/v1/community_businesses/visitors/__tests__/put.test.integration.ts
@@ -8,7 +8,7 @@ import { Credentials as StandardCredentials } from '../../../../../auth/strategi
 import { injectCfg } from '../../../../../../tests/utils/inject';
 
 
-describe('API /community-businesses/{id}/visitors', () => {
+describe('API PUT /community-businesses/me/visitors/{id}', () => {
   let server: Hapi.Server;
   let knex: Knex;
   let trx: Knex.Transaction;
@@ -42,102 +42,100 @@ describe('API /community-businesses/{id}/visitors', () => {
     server.app.knex = knex;
   });
 
-  describe('PUT /community-businesses/me/visitors/{id}', () => {
-    test('can perform partial update of user model', async () => {
-      const res = await server.inject(injectCfg({
-        method: 'PUT',
-        url: `/v1/community-businesses/me/visitors/${visitor.id}`,
-        payload: {
-          name: 'Tubby',
-        },
-        credentials,
-      }));
+  test('can perform partial update of user model', async () => {
+    const res = await server.inject(injectCfg({
+      method: 'PUT',
+      url: `/v1/community-businesses/me/visitors/${visitor.id}`,
+      payload: {
+        name: 'Tubby',
+      },
+      credentials,
+    }));
 
-      const { modifiedAt, createdAt, deletedAt, password, qrCode, ...rest } = visitor;
+    const { modifiedAt, createdAt, deletedAt, password, qrCode, ...rest } = visitor;
 
-      expect(res.statusCode).toBe(200);
-      expect(res.result).toEqual({
-        result: expect.objectContaining({ ...rest, name: 'Tubby' }),
-      });
-      expect((<any> res.result).result.modifiedAt).toBeTruthy();
-      expect((<any> res.result).result.modifiedAt).not.toBe(modifiedAt);
+    expect(res.statusCode).toBe(200);
+    expect(res.result).toEqual({
+      result: expect.objectContaining({ ...rest, name: 'Tubby' }),
     });
+    expect((<any> res.result).result.modifiedAt).toBeTruthy();
+    expect((<any> res.result).result.modifiedAt).not.toBe(modifiedAt);
+  });
 
-    test('can perform full update of user model', async () => {
-      const res = await server.inject(injectCfg({
-        method: 'PUT',
-        url: `/v1/community-businesses/me/visitors/${visitor.id}`,
-        payload: {
-          name: 'Tubby',
-          gender: 'male',
-          birthYear: 1972,
-          email: 'tubbs@aperture.com',
-          phoneNumber: '07892374881',
-          postCode: 'N4 98H',
-          isEmailConsentGranted: false,
-          isSMSConsentGranted: true,
-          disability: 'yes',
-          ethnicity: 'prefer not to say',
-        },
-        credentials,
-      }));
+  test('can perform full update of user model', async () => {
+    const res = await server.inject(injectCfg({
+      method: 'PUT',
+      url: `/v1/community-businesses/me/visitors/${visitor.id}`,
+      payload: {
+        name: 'Tubby',
+        gender: 'male',
+        birthYear: 1972,
+        email: 'tubbs@aperture.com',
+        phoneNumber: '07892374881',
+        postCode: 'H3 3LP',
+        isEmailConsentGranted: false,
+        isSMSConsentGranted: true,
+        disability: 'yes',
+        ethnicity: 'prefer not to say',
+      },
+      credentials,
+    }));
 
-      expect(res.statusCode).toBe(200);
-      expect(res.result).toEqual({
-        result: expect.objectContaining({
-          id: 1,
-          name: 'Tubby',
-          gender: 'male',
-          birthYear: 1972,
-          email: 'tubbs@aperture.com',
-          phoneNumber: '07892374881',
-          postCode: 'N4 98H',
-          isEmailConsentGranted: false,
-          isSMSConsentGranted: true,
-          disability: 'yes',
-          ethnicity: 'prefer not to say',
-        }),
-      });
-      expect((<any> res.result).result.modifiedAt).toBeTruthy();
-      expect((<any> res.result).result.modifiedAt).not.toBe(user.modifiedAt);
+    expect(res.statusCode).toBe(200);
+    expect(res.result).toEqual({
+      result: expect.objectContaining({
+        id: 1,
+        name: 'Tubby',
+        gender: 'male',
+        birthYear: 1972,
+        email: 'tubbs@aperture.com',
+        phoneNumber: '07892374881',
+        postCode: 'H3 3LP',
+        isEmailConsentGranted: false,
+        isSMSConsentGranted: true,
+        disability: 'yes',
+        ethnicity: 'prefer not to say',
+      }),
     });
+    expect((<any> res.result).result.modifiedAt).toBeTruthy();
+    expect((<any> res.result).result.modifiedAt).not.toBe(user.modifiedAt);
+  });
 
-    test('bad update data returns 400', async () => {
-      const res = await server.inject(injectCfg({
-        method: 'PUT',
-        url: `/v1/community-businesses/me/visitors/${visitor.id}`,
-        payload: {
-          name: 'Wheatley',
-          ethnicity: 'thisisprobablynotaethnicity',
-        },
-        credentials,
-      }));
+  test('bad update data returns 400', async () => {
+    const res = await server.inject(injectCfg({
+      method: 'PUT',
+      url: `/v1/community-businesses/me/visitors/${visitor.id}`,
+      payload: {
+        name: 'Wheatley',
+        ethnicity: 'thisisprobablynotaethnicity',
+      },
+      credentials,
+    }));
 
-      expect(res.statusCode).toBe(400);
-    });
+    expect(res.statusCode).toBe(400);
+  });
 
-    test('idempotency', async () => {
-      const res1 = await server.inject(injectCfg({
-        method: 'PUT',
-        url: `/v1/community-businesses/me/visitors/${visitor.id}`,
-        payload: {
-          name: 'Tubby',
-        },
-        credentials,
-      }));
+  test('idempotency', async () => {
+    const res1 = await server.inject(injectCfg({
+      method: 'PUT',
+      url: `/v1/community-businesses/me/visitors/${visitor.id}`,
+      payload: {
+        name: 'Tubby',
+      },
+      credentials,
+    }));
 
-      const res2 = await server.inject(injectCfg({
-        method: 'PUT',
-        url: `/v1/community-businesses/me/visitors/${visitor.id}`,
-        payload: {
-          name: 'Tubby',
-        },
-        credentials,
-      }));
+    const res2 = await server.inject(injectCfg({
+      method: 'PUT',
+      url: `/v1/community-businesses/me/visitors/${visitor.id}`,
+      payload: {
+        name: 'Tubby',
+      },
+      credentials,
+    }));
 
-      expect(res1.statusCode).toBe(200);
-      expect(res2.statusCode).toBe(200);
-      expect(res1.result).toEqual(res2.result);
-    });
+    expect(res1.statusCode).toBe(200);
+    expect(res2.statusCode).toBe(200);
+    expect(res1.result).toEqual(res2.result);
   });
 });

--- a/api/src/api/v1/users/__tests__/put.test.integration.ts
+++ b/api/src/api/v1/users/__tests__/put.test.integration.ts
@@ -9,7 +9,7 @@ import { Credentials as StandardCredentials } from '../../../../auth/strategies/
 import { injectCfg } from '../../../../../tests/utils/inject';
 
 
-describe('PUT /users/{userId}', () => {
+describe('PUT /users', () => {
   let server: Hapi.Server;
   let knex: Knex;
   let trx: Knex.Transaction;
@@ -198,7 +198,7 @@ describe('PUT /users/{userId}', () => {
           birthYear: 1972,
           email: 'tubbs@aperture.com',
           phoneNumber: '07892374881',
-          postCode: 'N4 98H',
+          postCode: 'N4 9HH',
           isEmailConsentGranted: false,
           isSMSConsentGranted: true,
           disability: 'yes',
@@ -216,7 +216,7 @@ describe('PUT /users/{userId}', () => {
           birthYear: 1972,
           email: 'tubbs@aperture.com',
           phoneNumber: '07892374881',
-          postCode: 'N4 98H',
+          postCode: 'N4 9HH',
           isEmailConsentGranted: false,
           isSMSConsentGranted: true,
           disability: 'yes',

--- a/api/src/api/v1/users/__tests__/roles.test.integration.ts
+++ b/api/src/api/v1/users/__tests__/roles.test.integration.ts
@@ -7,7 +7,7 @@ import { Credentials as StandardCredentials } from '../../../../auth/strategies/
 import { injectCfg } from '../../../../../tests/utils/inject';
 
 
-describe('GET /users/me/roles}', () => {
+describe('GET /users/me/roles', () => {
   let server: Hapi.Server;
   let knex: Knex;
   let user: User;

--- a/api/src/api/v1/users/__tests__/roles.test.integration.ts
+++ b/api/src/api/v1/users/__tests__/roles.test.integration.ts
@@ -7,7 +7,7 @@ import { Credentials as StandardCredentials } from '../../../../auth/strategies/
 import { injectCfg } from '../../../../../tests/utils/inject';
 
 
-describe('PUT /users/{userId}', () => {
+describe('GET /users/me/roles}', () => {
   let server: Hapi.Server;
   let knex: Knex;
   let user: User;
@@ -32,34 +32,32 @@ describe('PUT /users/{userId}', () => {
     await server.shutdown(true);
   });
 
-  describe('GET /users/me/roles', () => {
-    test('can get own roles', async () => {
-      const res = await server.inject(injectCfg({
-        method: 'GET',
-        url: '/v1/users/me/roles',
-        credentials,
-      }));
+  test('can get own roles', async () => {
+    const res = await server.inject(injectCfg({
+      method: 'GET',
+      url: '/v1/users/me/roles',
+      credentials,
+    }));
 
-      expect(res.statusCode).toBe(200);
-      expect(res.result).toEqual({
-        result: expect.objectContaining({ organisationId: organisation.id, roles: ['CB_ADMIN'] }),
-      });
+    expect(res.statusCode).toBe(200);
+    expect(res.result).toEqual({
+      result: expect.objectContaining({ organisationId: organisation.id, roles: ['CB_ADMIN'] }),
     });
+  });
 
-    test('can get own roles if have multiple', async () => {
-      const res = await server.inject(injectCfg({
-        method: 'GET',
-        url: '/v1/users/me/roles',
-        credentials: multiCredentials,
-      }));
+  test('can get own roles if have multiple', async () => {
+    const res = await server.inject(injectCfg({
+      method: 'GET',
+      url: '/v1/users/me/roles',
+      credentials: multiCredentials,
+    }));
 
-      expect(res.statusCode).toBe(200);
-      expect(res.result).toEqual({
-        result: expect.objectContaining({
-          organisationId: organisation.id,
-          roles: ['VISITOR', 'VOLUNTEER_ADMIN'],
-        }),
-      });
+    expect(res.statusCode).toBe(200);
+    expect(res.result).toEqual({
+      result: expect.objectContaining({
+        organisationId: organisation.id,
+        roles: ['VISITOR', 'VOLUNTEER_ADMIN'],
+      }),
     });
   });
 });

--- a/api/src/api/v1/users/__tests__/schema.test.unit.ts
+++ b/api/src/api/v1/users/__tests__/schema.test.unit.ts
@@ -1,0 +1,17 @@
+import * as Joi from '@hapi/joi';
+import { postCode } from '../schema';
+
+const ukPostCodeFormats = ['AA9A 9AA', 'A9A 9AA', 'A9 9AA', 'A99 9AA', 'AA9 9AA', 'AA99 9AA'];
+
+const postCodeTest = (format: string) => {
+  test(`Format ${format}`, () => {
+    const validation = Joi.validate(format, postCode);
+    expect(validation.error).toBeNull();
+  });
+};
+
+describe('User Schema Validation', () => {
+  describe('Post Code', () => {
+    ukPostCodeFormats.map((x) => postCodeTest(x));
+  });
+});

--- a/api/src/api/v1/users/register/__tests__/visitors.test.integration.ts
+++ b/api/src/api/v1/users/register/__tests__/visitors.test.integration.ts
@@ -64,6 +64,7 @@ describe('API v1 - register new users', () => {
           gender: 'female',
           birthYear: 1988,
           email: '1498@aperturescience.com',
+          postCode: 'ST10 4DB',
         },
         credentials,
       }));
@@ -84,6 +85,7 @@ describe('API v1 - register new users', () => {
           gender: 'male',
           birthYear: null,
           phoneNumber: '090909090909',
+          postCode: 'ST10 4DB',
         },
         credentials,
       }));
@@ -97,6 +99,7 @@ describe('API v1 - register new users', () => {
           gender: 'male',
           birthYear: null,
           phoneNumber: '090909090909',
+          postCode: 'ST10 4DB',
         },
         credentials,
       }));
@@ -116,6 +119,7 @@ describe('API v1 - register new users', () => {
           gender: 'female',
           birthYear: 1988,
           email: '13542@google.com',
+          postCode: 'ST10 4DB',
         },
         credentials,
       }));
@@ -135,6 +139,7 @@ describe('API v1 - register new users', () => {
           gender: 'female',
           birthYear: 1988,
           email: '13542@google.com',
+          postCode: 'ST10 4DB',
         },
         credentials,
       }));
@@ -154,6 +159,7 @@ describe('API v1 - register new users', () => {
           gender: 'female',
           birthYear: 1988,
           email: 'raiden@aotd.com', // email of VOLUNTEER_ADMIN
+          postCode: 'ST10 4DB',
         },
         credentials: credentialsBlackMesa,
       }));
@@ -174,6 +180,7 @@ describe('API v1 - register new users', () => {
           gender: 'female',
           birthYear: 1900,
           email: 'emma@sol.com',
+          postCode: 'ST10 4DB',
         },
         credentials,
       }));
@@ -195,6 +202,7 @@ describe('API v1 - register new users', () => {
           gender: 'female',
           birthYear: 1900,
           email: 'emma@sol.com',
+          postCode: 'ST10 4DB',
         },
         credentials: credentialsBlackMesa,
       }));
@@ -224,6 +232,7 @@ describe('API v1 - register new users', () => {
           name: 'Ratman',
           gender: 'male',
           birthYear: null,
+          postCode: 'ST10 4DB',
         },
         credentials,
       }));
@@ -242,6 +251,7 @@ describe('API v1 - register new users', () => {
           gender: 'female',
           birthYear: 1988,
           email: '13542@google.com',
+          postCode: 'ST10 4DB',
         },
         credentials,
       }));
@@ -265,6 +275,7 @@ describe('API v1 - register new users', () => {
           gender: 'female',
           birthYear: 1988,
           isAnonymous: true,
+          postCode: 'ST10 4DB',
         },
         credentials,
       }));
@@ -286,6 +297,7 @@ describe('API v1 - register new users', () => {
           gender: 'female',
           birthYear: 1988,
           isAnonymous: true,
+          postCode: 'ST10 4DB',
         },
         credentials,
       }));
@@ -309,6 +321,7 @@ describe('API v1 - register new users', () => {
           gender: 'male',
           birthYear: null,
           email: '666@aperturescience.com',
+          postCode: 'ST10 4DB',
         },
         credentials,
       }));
@@ -327,6 +340,7 @@ describe('API v1 - register new users', () => {
           gender: 'male',
           birthYear: null,
           phoneNumber: '090909090909',
+          postCode: 'ST10 4DB',
         },
         credentials,
       }));

--- a/api/src/api/v1/users/register/visitors.ts
+++ b/api/src/api/v1/users/register/visitors.ts
@@ -48,7 +48,7 @@ export default [
           birthYear: birthYear.default(null),
           email,
           phoneNumber,
-          postCode: postCode.allow(''),
+          postCode: postCode.required(),
           emailConsent: isEmailConsentGranted.default(false),
           smsConsent: isSMSConsentGranted.default(false),
           isAnonymous: Joi.boolean().default(false) ,

--- a/api/src/api/v1/users/schema.ts
+++ b/api/src/api/v1/users/schema.ts
@@ -63,6 +63,7 @@ export const postCode =
   Joi.string()
     .min(4)
     .max(10)
+    .regex(/^[a-z]{1,2}\d[a-z\d]?\s*\d[a-z]{2}$/i)
     .trim();
 
 export const isEmailConsentGranted =

--- a/api/src/api/v1/users/schema.ts
+++ b/api/src/api/v1/users/schema.ts
@@ -63,8 +63,9 @@ export const postCode =
   Joi.string()
     .min(4)
     .max(10)
-    .regex(/^[a-z]{1,2}\d[a-z\d]?\s*\d[a-z]{2}$/i)
-    .trim();
+    .regex(/^[a-z]{1,2}\d[a-z\d]?\s*\d[a-z]{2}$/i, { name: 'format' })
+    .trim()
+    .options({ language: { string: { regex: { name: 'invalid post code' } } } });
 
 export const isEmailConsentGranted =
   Joi.boolean();

--- a/visitor-app/src/api/index.js
+++ b/visitor-app/src/api/index.js
@@ -71,6 +71,7 @@ export const Visitors = {
       smsConsent,
       organisationId,
       isAnonymous,
+      postCode,
     } = {},
   ) =>
     axios.post(
@@ -85,6 +86,7 @@ export const Visitors = {
         smsConsent,
         organisationId,
         isAnonymous,
+        postCode,
       }),
     ),
 

--- a/visitor-app/src/visitors/index.js
+++ b/visitor-app/src/visitors/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 import Home from './pages/homeVisitor';
-import Signup from './pages/Signup';
+import Signup from './pages/SignUp/index';
 import Thanks from './pages/thanks';
 import ThanksFeedback from './pages/thank_you_feedback';
 import QrError from './pages/qrerror';

--- a/visitor-app/src/visitors/pages/SignUp/index.js
+++ b/visitor-app/src/visitors/pages/SignUp/index.js
@@ -67,13 +67,6 @@ export default class Main extends Component {
     super(props);
 
     this.state = {
-      fullname: '',
-      email: '',
-      phone: '',
-      gender: '',
-      year: '',
-      emailContact: false,
-      smsContact: false,
       users: [],
       genders: [],
       qrCode: '',
@@ -138,7 +131,7 @@ export default class Main extends Component {
   createVisitor = (e) => {
     e.preventDefault();
 
-    if (!this.state.phone && !this.state.email) {
+    if (!this.state.phoneNumber && !this.state.email) {
       return this.setState({ errors: { email: 'You must supply a phone number or email address' } });
     }
 
@@ -146,13 +139,12 @@ export default class Main extends Component {
       return this.setState({ errors: { ageCheck: 'You must be over 13 to register' } });
     }
 
-    console.log(this.state);
     return Visitors.create({
       name: this.state.fullname,
       gender: this.state.gender,
       birthYear: this.state.year,
       email: this.state.email,
-      phoneNumber: this.state.phone,
+      phoneNumber: this.state.phoneNumber,
       emailConsent: this.state.emailContact,
       smsConsent: this.state.smsContact,
       organisationId: this.state.organisationId,

--- a/visitor-app/src/visitors/pages/SignUp/index.js
+++ b/visitor-app/src/visitors/pages/SignUp/index.js
@@ -2,15 +2,15 @@ import React, { Component } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import SignupForm from '../components/signup_form';
-import NotFound from '../../shared/components/NotFound';
-import { CommunityBusiness, Visitors, ErrorUtils } from '../../api';
-import { Heading, Paragraph, Link } from '../../shared/components/text/base';
-import { PrimaryButton } from '../../shared/components/form/base';
-import { FlexContainerCol, FlexContainerRow } from '../../shared/components/layout/base';
-import { renameKeys, redirectOnError } from '../../util';
-import { BirthYear } from '../../shared/constants';
-import PrintableQrCode from '../../shared/components/PrintableQrCode';
+import SignupForm from './signup_form';
+import NotFound from '../../../shared/components/NotFound';
+import { CommunityBusiness, Visitors, ErrorUtils } from '../../../api';
+import { Heading, Paragraph, Link } from '../../../shared/components/text/base';
+import { PrimaryButton } from '../../../shared/components/form/base';
+import { FlexContainerCol, FlexContainerRow } from '../../../shared/components/layout/base';
+import { renameKeys, redirectOnError } from '../../../util';
+import { BirthYear } from '../../../shared/constants';
+import PrintableQrCode from '../../../shared/components/PrintableQrCode';
 
 
 const ButtonsFlexContainerCol = styled(FlexContainerCol)`
@@ -146,6 +146,7 @@ export default class Main extends Component {
       return this.setState({ errors: { ageCheck: 'You must be over 13 to register' } });
     }
 
+    console.log(this.state);
     return Visitors.create({
       name: this.state.fullname,
       gender: this.state.gender,
@@ -155,6 +156,7 @@ export default class Main extends Component {
       emailConsent: this.state.emailContact,
       smsConsent: this.state.smsContact,
       organisationId: this.state.organisationId,
+      postCode: this.state.postCode,
     })
       .then((res) => {
         this.setState({ qrCode: res.data.result.qrCode });

--- a/visitor-app/src/visitors/pages/SignUp/signup_form.js
+++ b/visitor-app/src/visitors/pages/SignUp/signup_form.js
@@ -90,9 +90,9 @@ const signupForm = (props) => {
               <LabelledInput
                 id="visitor-signup-phonenumber"
                 label="Phone Number"
-                name={`phone$${props.uuid}`}
+                name={`phoneNumber$${props.uuid}`}
                 type="text"
-                error={props.errors.number}
+                error={props.errors.phoneNumber}
               />
               <LabelledInput
                 id="visitor-signup-postcode"

--- a/visitor-app/src/visitors/pages/SignUp/signup_form.js
+++ b/visitor-app/src/visitors/pages/SignUp/signup_form.js
@@ -11,15 +11,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Grid, Row } from 'react-flexbox-grid';
-import { Form as FM, FormSection, PrimaryButton } from '../../shared/components/form/base';
-import { Paragraph } from '../../shared/components/text/base';
-import LabelledInput from '../../shared/components/form/LabelledInput';
-import StyledLabelledCheckbox from '../../shared/components/form/StyledLabelledCheckbox';
-import LabelledSelect from '../../shared/components/form/LabelledSelect';
-import { FlexContainerRow } from '../../shared/components/layout/base';
-import NavHeader from '../../shared/components/NavHeader';
-import { colors, fonts } from '../../shared/style_guide';
-import { VISITOR_NAME_INVALID } from '../../cb_admin/constants/error_text';
+import { Form as FM, FormSection, PrimaryButton } from '../../../shared/components/form/base';
+import { Paragraph } from '../../../shared/components/text/base';
+import LabelledInput from '../../../shared/components/form/LabelledInput';
+import StyledLabelledCheckbox from '../../../shared/components/form/StyledLabelledCheckbox';
+import LabelledSelect from '../../../shared/components/form/LabelledSelect';
+import { FlexContainerRow } from '../../../shared/components/layout/base';
+import NavHeader from '../../../shared/components/NavHeader';
+import { colors, fonts } from '../../../shared/style_guide';
+import { VISITOR_NAME_INVALID } from '../../../cb_admin/constants/error_text';
 
 
 const Form = styled(FM)`
@@ -93,6 +93,14 @@ const signupForm = (props) => {
                 name={`phone$${props.uuid}`}
                 type="text"
                 error={props.errors.number}
+              />
+              <LabelledInput
+                id="visitor-signup-postcode"
+                label="Post Code"
+                name={`postCode$${props.uuid}`}
+                type="text"
+                error={props.errors.postCode}
+                required
               />
               <LabelledSelect
                 id="visitor-signup-gender"

--- a/visitor-app/src/visitors/pages/__tests__/Signup.test.js
+++ b/visitor-app/src/visitors/pages/__tests__/Signup.test.js
@@ -7,7 +7,7 @@ import {
 import MockAdapter from 'axios-mock-adapter';
 import { axios } from '../../../api';
 import { renderWithRouter } from '../../../tests';
-import main from '../Signup';
+import main from '../SignUp/index';
 
 
 describe('Visitor Registration Component', () => {


### PR DESCRIPTION
relates https://github.com/TwinePlatform/twine-visitor/issues/643

### Changes
- add postcode validation with tests
- set post code as required for visitor registration
- add postcode field to visitor sign up on visitor app
- fix error messages for phone number as this wasn't displaying
- minor visitor app file rearranging

### Testing Requirements
- [x] *Visitor App*
  - try to sign up without a postcode = ⁉️ validation error message
  - try to sign up with an postcode > 10 characters = ⁉️ validation error message
  - try to sign up with an invalid postcode format eg all numbers or all letters = ⁉️ validation error message

### Release Requirements
- minor (Devs to release); validation required on postcode

### Manual Deployment
- Visitor App
- API
