### PR TITLE
🐛 fix userId bug in volunteer app sync

### DIFF
--- a/volunteer-app/www/js/app.js
+++ b/volunteer-app/www/js/app.js
@@ -193,10 +193,10 @@
 						logsData.logs = logsData.logs.map(function (log) {
 							return {
 								id: log.id || undefined,
-								userId: log.userId === userId ? undefined : log.userId,
+								userId: (log.userId || log.user_id) == userId ? undefined : (log.userId || log.user_id),
 								duration: typeof log.duration === 'number' ? { minutes: log.duration } : log.duration,
 								activity: log.activity,
-								startedAt: log.date_of_log,
+								startedAt: log.date_of_log || log.startedAt,
 								project: log.project,
 								deletedAt: log.deletedAt || undefined,
 							}


### PR DESCRIPTION
related to #259 #246 

### Changes
- Ensure `userId` is specified in sync payload if available
  - Complicated by inconsistent use of snake and camel case 😔
- Fallback to `startedAt` if `date_of_log` unavailable

### Testing Requirements
- [x] Volunteer app
  - Online mode
    - Create log as `VOLUNTEER`
    - Check DB records user ID accurately
    - Create log as `VOLUNTEER_ADMIN`
    - Check DB records user ID accurately
    - Create log for `VOLUNTEER` as `VOLUNTEER_ADMIN`
    - Check DB records user ID accurately
  - Offline mode
    - Enter offline mode on "view logs" screen
    - Repeat steps above, syncing logs after each step.

### Release Requirements
- Bundled with other volunteer app changes

### Manual Deployment
- Volunteer app