### PR TITLE
🚸 display overlay when no data in range

### DIFF
--- a/dashboard-app/src/features/dashboard/components/StackedBarChart/Chart.tsx
+++ b/dashboard-app/src/features/dashboard/components/StackedBarChart/Chart.tsx
@@ -21,7 +21,7 @@ interface Props {
   xAxisTitle: string;
   yAxisTitle: string;
   title: TitleString;
-  noActiveLegendText: string;
+  overlayText?: string;
   isVisible: boolean;
   tooltipUnit: string;
 }
@@ -77,7 +77,7 @@ const Chart: FunctionComponent<Props> = (props) => {
     yAxisTitle,
     title,
     isVisible,
-    noActiveLegendText,
+    overlayText,
     tooltipUnit,
   } = props;
 
@@ -88,7 +88,7 @@ const Chart: FunctionComponent<Props> = (props) => {
         <Col xs={12} md={9}>
           <GraphContentContainer>
             <HideableTextOverlay isVisible={isVisible}>
-              <TransitionText isVisible={isVisible}>{noActiveLegendText}</TransitionText >
+              <TransitionText isVisible={isVisible}>{overlayText}</TransitionText >
             </HideableTextOverlay>
             <RoundedBar
               datasetKeyProvider={datasetKeyProvider}

--- a/dashboard-app/src/features/dashboard/components/StackedBarChart/index.tsx
+++ b/dashboard-app/src/features/dashboard/components/StackedBarChart/index.tsx
@@ -31,10 +31,31 @@ interface Props {
   defaultSelection: boolean;
 }
 
+
+/*
+ * Helpers
+ */
+
+const getOverlayText = (data: AggregatedData, legendItemsActive: boolean): [boolean, string] => {
+  const noActiveLegendText = data.groupByX === 'Activity'
+    ? 'Select an activity to show data'
+    : 'Select volunteers to show their hours';
+
+  const dataExists = data.rows.length > 0;
+
+  if (!dataExists) {
+    return [true, 'No data for this range']
+  } else if (!legendItemsActive) {
+    return [true, noActiveLegendText];
+  } else {
+    return [false, ''];
+  }
+};
+
+
 /*
  * Components
  */
-
 const StackedBarChart: FunctionComponent<Props> = (props) => {
   const { data, xAxisTitle, yAxisTitle, title, legendData, setLegendData, defaultSelection } = props;
   const {unit} = useContext(DashboardContext)
@@ -102,20 +123,3 @@ const StackedBarChart: FunctionComponent<Props> = (props) => {
 };
 
 export default StackedBarChart;
-
-
-const getOverlayText = (data: AggregatedData, legendItemsActive: boolean): [boolean, string] => {
-  const noActiveLegendText = data.groupByX === 'Activity'
-    ? 'Select an activity to show data'
-    : 'Select volunteers to show their hours';
-
-  const dataExists = data.rows.length > 0;
-
-  if (!dataExists) {
-    return [true, 'No data for this range']
-  } else if (!legendItemsActive) {
-    return [true, noActiveLegendText];
-  } else {
-    return [false, ''];
-  }
-}

--- a/dashboard-app/src/features/dashboard/components/StackedBarChart/index.tsx
+++ b/dashboard-app/src/features/dashboard/components/StackedBarChart/index.tsx
@@ -69,19 +69,16 @@ const StackedBarChart: FunctionComponent<Props> = (props) => {
     setTooltipUnit(unit === DurationUnitEnum.DAYS ? 'days' : 'hrs');
   }, [unit]);
 
-  const noActiveLegendText = data.groupByX === 'Activity'
-    ? 'Select an activity to show data'
-    : 'Select volunteers to show their hours';
+  const [isVisible, overlayText] = getOverlayText(data, !isEveryDatumInactive(legendData));
 
-  const isThereData = data.rows.length > 0;
   const chartProps = {
     data: chartData,
     xAxisTitle,
     yAxisTitle,
     title,
     tooltipUnit,
-    noActiveLegendText,
-    isVisible: isEveryDatumInactive(legendData) && isThereData,
+    overlayText,
+    isVisible,
   };
 
   const legendProps = {
@@ -106,3 +103,19 @@ const StackedBarChart: FunctionComponent<Props> = (props) => {
 
 export default StackedBarChart;
 
+
+const getOverlayText = (data: AggregatedData, legendItemsActive: boolean): [boolean, string] => {
+  const noActiveLegendText = data.groupByX === 'Activity'
+    ? 'Select an activity to show data'
+    : 'Select volunteers to show their hours';
+
+  const dataExists = data.rows.length > 0;
+
+  if (!dataExists) {
+    return [true, 'No data for this range']
+  } else if (!legendItemsActive) {
+    return [true, noActiveLegendText];
+  } else {
+    return [false, ''];
+  }
+}

--- a/dashboard-app/src/features/dashboard/dataManipulation/logsToAggregatedData.ts
+++ b/dashboard-app/src/features/dashboard/dataManipulation/logsToAggregatedData.ts
@@ -69,7 +69,7 @@ export const logsToAggregatedData = ({ logs, tableType, xData, yData }: Params):
     if (exists) {
       return rowsAcc.map((row) => {
         if (checkIfRowExists(row, tableType, log)) {
-          row[activeColumn] = Duration.sum(row[activeColumn], log.duration);
+          row[activeColumn] = Duration.sum(row[activeColumn] || {}, log.duration);
         }
         return row;
       });


### PR DESCRIPTION
Found this stuff in the course of working on #32 but thought it should be split out.

### Changes
- Display overlay when `data` is empty
- Rename `noActiveLegendText` to `overlayText` since it is also triggered when there's no data in the selected range.
- Fix bug found in `logsToAggregatedData` where an empty range sometimes causes a crash

### Testing Requirements
- [x] Dashboard
  - Go to `/time` or `/volunteer`
  - Select a date range with no data
  - Observe overlay message

### Release Requirements
- Minor change, release when ready

### Manual Deployment
- Dashboard
