### PR TITLE
🐛 fix external API access issues

### DIFF
--- a/api/bin/api_token.ts
+++ b/api/bin/api_token.ts
@@ -35,14 +35,15 @@ if (!cb || !scope) {
     if (!exists) {
       throw new Error(`No community business by the name ${cb} was found`);
     }
-
-    const tkn = await ApiTokens.add(client, ApiTokens.create(cb, scope));
+    const tkn = ApiTokens.create(cb, scope)
+    const { id } = await ApiTokens.add(client, tkn);
 
     console.log(`
       API token added to ${env} database:
-        ID: ${tkn.id}
+        ID: ${id}
         Name: ${tkn.name}
         Access: ${tkn.access}
+        Token: ${tkn.token}
     `);
 
   } catch (error) {

--- a/api/src/auth/schema/session_cookie/index.ts
+++ b/api/src/auth/schema/session_cookie/index.ts
@@ -39,7 +39,10 @@ export default {
           const isAuthenticated = request.yar.get('isAuthenticated');
 
           if (!isAuthenticated) {
-            return h.unauthenticated(Boom.unauthorized());
+            // Must pass `null` as the error and schema name to Boom constructor
+            // in order to allow other auth schema to attempt authentication
+            // See https://hapi.dev/api/?v=18.3.2#server.auth.scheme()
+            return h.unauthenticated(Boom.unauthorized(null, 'session_cookie'));
           }
 
           try {


### PR DESCRIPTION
### Changes
- Fix `api_token` script so it actually prints the API token
- Call `Boom` in the special way that we need to in order to ensure other schema are also checked.

### Testing Requirements
- [ ] API
  - Create an API token for a CB using the script
  - Use the API token to send a request to an open endpoint (e.g. cb/me/visitors)

### Release Requirements
- When ready

### Manual Deployment
- API