### PR TITLE
♻️ force failure in pre-reqs to avoid having to manually fail in…

### DIFF
--- a/api/src/api/v1/community_businesses/cb_admins/__tests__/get.test.integration.ts
+++ b/api/src/api/v1/community_businesses/cb_admins/__tests__/get.test.integration.ts
@@ -11,8 +11,10 @@ describe('GET /community-businesses/{id}/cb-admins', () => {
   let server: Hapi.Server;
   let knex: Knex;
   let admin: User;
+  let user: User;
   let organisation: Organisation;
   let adminCreds: Hapi.AuthCredentials;
+  let userCreds: Hapi.AuthCredentials;
   const config = getConfig(process.env.NODE_ENV);
 
   beforeAll(async () => {
@@ -20,8 +22,10 @@ describe('GET /community-businesses/{id}/cb-admins', () => {
     knex = server.app.knex;
 
     admin = await Users.getOne(knex, { where: { name: 'Big Boss' } });
+    user = await Users.getOne(knex, { where: { name: 'Chell' } });
     organisation = await Organisations.getOne(knex, { where: { id: 1 } });
     adminCreds = await StandardCredentials.create(knex, admin, organisation);
+    userCreds = await StandardCredentials.create(knex, user, organisation);
   });
 
   afterAll(async () => {
@@ -41,6 +45,18 @@ describe('GET /community-businesses/{id}/cb-admins', () => {
       deletedAt: null,
     }));
     expect((<any> res.result).meta).toEqual({ total: 1 });
+  });
 
+  test('403 if not TWINE_ADMIN', async () => {
+    const res = await server.inject(injectCfg({
+      method: 'GET',
+      url: '/v1/community-businesses/1/cb-admins',
+      credentials: userCreds,
+    }));
+    expect(res.statusCode).toBe(403);
+    expect((<any> res.result).error).toEqual(expect.objectContaining({
+      message: 'Insufficient scope',
+      type: 'Forbidden',
+    }));
   });
 });

--- a/api/src/api/v1/community_businesses/cb_admins/get.ts
+++ b/api/src/api/v1/community_businesses/cb_admins/get.ts
@@ -1,9 +1,7 @@
-import * as Hapi from '@hapi/hapi';
-import * as Boom from '@hapi/boom';
 import { CbAdmins } from '../../../../models';
 import { response } from '../../users/schema';
 import { id } from '../schema';
-import { getCommunityBusiness, isChildOrganisation } from '../../prerequisites';
+import { getCommunityBusiness, requireChildOrganisation } from '../../prerequisites';
 import { Api } from '../../types/api';
 
 
@@ -25,15 +23,11 @@ const routes: [Api.CommunityBusinesses.CbAdmins.GET.Route] = [
       response: { schema: response },
       pre: [
         { method: getCommunityBusiness, assign: 'communityBusiness' },
-        { method: isChildOrganisation, assign: 'isChild' },
+        { method: requireChildOrganisation },
       ],
     },
-    handler: async (request, h: Hapi.ResponseToolkit) => {
-      const { pre: { communityBusiness, isChild }, server: { app: { knex } } } = request;
-
-      if (!isChild) {
-        return Boom.forbidden('Insufficient permissions to access this resource');
-      }
+    handler: async (request, h) => {
+      const { pre: { communityBusiness }, server: { app: { knex } } } = request;
 
       const admins = await CbAdmins.fromOrganisation(knex, communityBusiness);
 

--- a/api/src/api/v1/community_businesses/feedback.ts
+++ b/api/src/api/v1/community_businesses/feedback.ts
@@ -1,9 +1,8 @@
-import * as Boom from '@hapi/boom';
 import * as Joi from '@hapi/joi';
 import { CommunityBusinesses } from '../../../models';
 import { Api } from '../types/api';
 import { query, response, since, until } from './schema';
-import { getCommunityBusiness, isChildOrganisation } from '../prerequisites';
+import { getCommunityBusiness, requireChildOrganisation } from '../prerequisites';
 import { Credentials as StandardCredentials } from '../../../auth/strategies/standard';
 import { Feedback } from '../../../models/types';
 
@@ -64,15 +63,11 @@ const routes: [
       response: { schema: response },
       pre: [
         { method: getCommunityBusiness , assign: 'communityBusiness' },
-        { method: isChildOrganisation , assign: 'isChild' },
+        requireChildOrganisation
       ],
     },
     handler: async (request, h) => {
-      const { pre: { communityBusiness, isChild }, query, server: { app: { knex } } } = request;
-
-      if (!isChild) {
-        return Boom.forbidden('Cannot access this organisation');
-      }
+      const { pre: { communityBusiness }, query, server: { app: { knex } } } = request;
 
       const since = new Date(query.since);
       const until = new Date(query.until);

--- a/api/src/api/v1/community_businesses/put.ts
+++ b/api/src/api/v1/community_businesses/put.ts
@@ -1,6 +1,6 @@
 import * as Boom from '@hapi/boom';
 import { CommunityBusinesses } from '../../../models';
-import { getCommunityBusiness, isChildOrganisation } from '../prerequisites';
+import { getCommunityBusiness, requireChildOrganisation } from '../prerequisites';
 import { Api } from '../types/api';
 import { id, response, cbPayload } from './schema';
 
@@ -77,15 +77,11 @@ const routes: [
       response: { schema: response },
       pre: [
         { method: getCommunityBusiness, assign: 'communityBusiness' },
-        { method: isChildOrganisation, assign: 'isChild' },
+        requireChildOrganisation,
       ],
     },
     handler: async (request, h) => {
-      const { payload: changeSet, pre: { communityBusiness, isChild }, server: { app: { knex } } } = request;
-
-      if (!isChild) {
-        return Boom.forbidden('Insufficient permissions to access this resource');
-      }
+      const { payload: changeSet, pre: { communityBusiness }, server: { app: { knex } } } = request;
 
       if (communityBusiness.isTemp) {
         return Boom.forbidden('Temporary organisation');

--- a/api/src/api/v1/community_businesses/register.ts
+++ b/api/src/api/v1/community_businesses/register.ts
@@ -2,13 +2,10 @@ import * as Boom from '@hapi/boom';
 import { omit } from 'ramda';
 
 import { CommunityBusinesses, Users, CbAdmins } from '../../../models';
-import { isChildOrganisation } from '../prerequisites';
+import { requireChildOrganisation } from '../prerequisites';
 import { Api } from '../types/api';
 import { response, cbPayload } from './schema';
-import {
-  userName,
-  email,
-} from '../users/schema';
+import { userName, email } from '../users/schema';
 import { Tokens } from '../../../models/token';
 
 
@@ -32,9 +29,7 @@ const routes: [Api.CommunityBusinesses.Register.POST.Route] = [
           adminEmail: email.required(),
         },
       },
-      pre: [
-        { method: isChildOrganisation, assign: 'isChild', failAction: 'error' },
-      ],
+      pre: [requireChildOrganisation],
       response: { schema: response },
     },
     handler: async (request, h) => {

--- a/api/src/api/v1/community_businesses/temporary/delete.ts
+++ b/api/src/api/v1/community_businesses/temporary/delete.ts
@@ -1,5 +1,5 @@
 import * as Boom from '@hapi/boom';
-import { getCommunityBusiness, isChildOrganisation } from '../../prerequisites';
+import { getCommunityBusiness, requireChildOrganisation } from '../../prerequisites';
 import { id, response } from '../schema';
 import { Api } from '../../types/api';
 
@@ -22,15 +22,11 @@ const routes: [Api.CommunityBusinesses.Temporary.Id.DELETE.Route] = [
       response: { schema: response },
       pre: [
         { method: getCommunityBusiness, assign: 'communityBusiness' },
-        { method: isChildOrganisation, assign: 'isChild' },
+        requireChildOrganisation,
       ],
     },
     handler: async (request, h) => {
-      const { pre: { communityBusiness, isChild }, server: { app: { knex } } } = request;
-
-      if (!isChild) {
-        return Boom.forbidden('Insufficient permissions to access this resource');
-      }
+      const { pre: { communityBusiness }, server: { app: { knex } } } = request;
 
       if (!communityBusiness.isTemp) {
         return Boom.forbidden('Not a temporary organisation');

--- a/api/src/api/v1/community_businesses/temporary/get.ts
+++ b/api/src/api/v1/community_businesses/temporary/get.ts
@@ -1,4 +1,4 @@
-import { isChildOrganisation } from '../../prerequisites';
+import { requireChildOrganisation } from '../../prerequisites';
 import { response } from '../schema';
 import { CommunityBusinesses } from '../../../../models';
 import { Api } from '../../types/api';
@@ -16,9 +16,7 @@ const routes: [Api.CommunityBusinesses.Temporary.GET.Route] = [
           scope: ['organisations_details-child:read'],
         },
       },
-      pre: [
-        { method: isChildOrganisation, assign: 'isChild', failAction: 'error' },
-      ],
+      pre: [requireChildOrganisation],
       response: { schema: response },
     },
     handler: async (request, h) => {

--- a/api/src/api/v1/community_businesses/temporary/password_reset.ts
+++ b/api/src/api/v1/community_businesses/temporary/password_reset.ts
@@ -1,6 +1,6 @@
 import * as Boom from '@hapi/boom';
 import { Random } from 'twine-util';
-import { isChildOrganisation, getCommunityBusiness } from '../../prerequisites';
+import { getCommunityBusiness, requireChildOrganisation } from '../../prerequisites';
 import { response, id } from '../schema';
 import { CbAdmins, Users } from '../../../../models';
 import { Api } from '../../types/api';
@@ -20,7 +20,7 @@ const routes: [Api.CommunityBusinesses.Temporary.Id.Password.Reset.GET.Route] = 
       },
       pre: [
         { method: getCommunityBusiness, assign: 'communityBusiness' },
-        { method: isChildOrganisation, failAction: 'error' },
+        requireChildOrganisation,
       ],
       validate: {
         params: { organisationId: id },

--- a/api/src/api/v1/community_businesses/temporary/register.ts
+++ b/api/src/api/v1/community_businesses/temporary/register.ts
@@ -1,6 +1,5 @@
-import * as Boom from '@hapi/boom';
 import { CommunityBusinesses, CbAdmins } from '../../../../models';
-import { isChildOrganisation } from '../../prerequisites';
+import { requireChildOrganisation } from '../../prerequisites';
 import { Api } from '../../types/api';
 import { response, cbPayload } from '../schema';
 
@@ -22,21 +21,14 @@ const routes: [Api.CommunityBusinesses.Register.Temporary.POST.Route] = [
           orgName: cbPayload.name.required(),
         },
       },
-      pre: [
-        { method: isChildOrganisation, assign: 'isChild', failAction: 'error' },
-      ],
+      pre: [requireChildOrganisation],
       response: { schema: response },
     },
     handler: async (request, h) => {
       const {
-        pre: { isChild },
         server: { app: { knex } },
         payload: { orgName },
       } = request;
-
-      if (!isChild) {
-        return Boom.forbidden('Insufficient permissions to create organisations');
-      }
 
       // Create accounts
       const { admin, cb } = await knex.transaction(async (trx) => {

--- a/api/src/api/v1/community_businesses/visit_activities.ts
+++ b/api/src/api/v1/community_businesses/visit_activities.ts
@@ -1,7 +1,7 @@
 import * as Boom from '@hapi/boom';
 import * as moment from 'moment' ;
 import { CommunityBusinesses } from '../../../models';
-import { getCommunityBusiness, isChildOrganisation } from '../prerequisites';
+import { getCommunityBusiness, requireChildOrganisation } from '../prerequisites';
 import {
   response,
   visitActivitiesPostPayload,
@@ -164,7 +164,7 @@ const routes: [
       },
       pre: [
         { method: getCommunityBusiness, assign: 'communityBusiness' },
-        { method: isChildOrganisation, assign: 'isChild', failAction: 'error' },
+        requireChildOrganisation,
       ],
       validate: {
         query: visitActivitiesGetQuery,
@@ -174,14 +174,10 @@ const routes: [
     },
     handler: async (request, h) => {
       const {
-        pre: { communityBusiness, isChild },
+        pre: { communityBusiness },
         query: { day: _day = null },
         server: { app: { knex } }
       } = request;
-
-      if (!isChild) {
-        return Boom.forbidden('Access to this resource is forbidden');
-      }
 
       const day = _day === 'today'
         ? moment().format('dddd').toLowerCase() as Weekday

--- a/api/src/api/v1/community_businesses/visitors/email.ts
+++ b/api/src/api/v1/community_businesses/visitors/email.ts
@@ -1,7 +1,7 @@
 import * as Boom from '@hapi/boom';
 import * as Joi from '@hapi/joi';
 import { response, id } from '../schema';
-import { isChildUser } from '../../prerequisites';
+import { requireChildUser } from '../../prerequisites';
 import { Visitors, CommunityBusinesses } from '../../../../models';
 import * as PdfService from '../../../../services/pdf';
 import * as QRCode from '../../../../services/qrcode';
@@ -32,22 +32,15 @@ const routes: [
         },
       },
       response: { schema: response },
-      pre: [
-        { method: isChildUser, assign: 'isChild' },
-      ],
+      pre: [requireChildUser],
     },
     handler: async (request, h) => {
       const {
-        pre: { isChild },
         params: { userId },
         server: { app: { knex, EmailService, config } },
       } = request;
 
       const { organisation } = StandardCredentials.fromRequest(request);
-
-      if (!isChild) {
-        return Boom.forbidden('Insufficient permissions to access this resource');
-      }
 
       const cb = await CommunityBusinesses.getOne(knex, { where: { id: organisation.id } });
 

--- a/api/src/api/v1/community_businesses/visitors/put.ts
+++ b/api/src/api/v1/community_businesses/visitors/put.ts
@@ -16,7 +16,7 @@ import {
 } from '../../users/schema';
 import { meOrId } from '../schema';
 import { Api } from '../../types/api';
-import { getCommunityBusiness, isChildUser } from '../../prerequisites';
+import { getCommunityBusiness, requireChildUser } from '../../prerequisites';
 
 
 const routes: [
@@ -54,20 +54,16 @@ const routes: [
       response: { schema: response },
       pre: [
         { method: getCommunityBusiness , assign: 'communityBusiness' },
-        { method: isChildUser, assign: 'isChild' },
+        requireChildUser,
       ],
     },
     handler: async (request, h) => {
       const {
         server: { app: { knex } },
         payload,
-        pre: { isChild, communityBusiness },
+        pre: { communityBusiness },
         params: { userId },
       } = request;
-
-      if (!isChild) {
-        return Boom.forbidden('Insufficient permission to access this resource');
-      }
 
       const changeset = { ...payload };
 

--- a/api/src/api/v1/prerequisites/get_organisation.ts
+++ b/api/src/api/v1/prerequisites/get_organisation.ts
@@ -11,10 +11,13 @@ import * as Boom from '@hapi/boom';
 import { Organisations } from '../../../models';
 import { getCredentialsFromRequest } from '../auth';
 
+interface Request extends Hapi.Request {
+  params: { organisationId?: string };
+}
 
 const is360GivingId = (s: string) => isNaN(parseInt(s, 10));
 
-export default async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
+export default async (request: Request, h: Hapi.ResponseToolkit) => {
   const { params: { organisationId: id }, server: { app: { knex } } } = request;
 
   const organisation =

--- a/api/src/api/v1/prerequisites/index.ts
+++ b/api/src/api/v1/prerequisites/index.ts
@@ -3,6 +3,9 @@ import getCommunityBusiness from './get_community_business';
 import isChildOrganisation from './is_child_organisation';
 import isParentOrganisation from './is_parent_organisation';
 import isChildUser from './is_child_user';
+import requireChildOrganisation from './require_child_organisation';
+import requireParentOrganisation from './require_parent_organisation';
+import requireChildUser from './require_child_user';
 import requireSiblingUser from './require_sibling_user';
 
 export {
@@ -11,5 +14,8 @@ export {
   isChildOrganisation,
   isParentOrganisation,
   isChildUser,
-  requireSiblingUser
+  requireChildOrganisation,
+  requireParentOrganisation,
+  requireChildUser,
+  requireSiblingUser,
 };

--- a/api/src/api/v1/prerequisites/is_child_organisation.ts
+++ b/api/src/api/v1/prerequisites/is_child_organisation.ts
@@ -5,8 +5,6 @@
  * which is actually a "child" entity.
  *
  * Conditions under which this is true for organisation X:
- * - User is an admin for a funding body which owns at least
- *   one funding programme of which X is a member
  * - User is a Twine admin
  *
  */

--- a/api/src/api/v1/prerequisites/is_child_user.ts
+++ b/api/src/api/v1/prerequisites/is_child_user.ts
@@ -6,8 +6,8 @@
  *
  * Conditions under which this is true for user X attemptying to access:
  * user Y
- * - User X is an admin for a community business for which user Y is a VISITOR
- * - User X is an admin for a community business for which user Y is a VOLUNTEER
+ * - User X is a CB_ADMIN for a community business for which user Y is a VISITOR
+ * - User X is a CB_ADMIN for a community business for which user Y is a VOLUNTEER
  * - User X is a Twine admin
  *
  */

--- a/api/src/api/v1/prerequisites/is_child_user.ts
+++ b/api/src/api/v1/prerequisites/is_child_user.ts
@@ -10,8 +10,6 @@
  * - User X is an admin for a community business for which user Y is a VOLUNTEER
  * - User X is a Twine admin
  *
- * NOTE: Funding body admins should not be allowed to access user information of
- *       VISITOR or VOLUNTEER users at child community-businesses for GDPR reasons
  */
 import * as Hapi from '@hapi/hapi';
 import Roles from '../../../models/role';

--- a/api/src/api/v1/prerequisites/is_parent_organisation.ts
+++ b/api/src/api/v1/prerequisites/is_parent_organisation.ts
@@ -7,15 +7,12 @@
  * Conditions under which this is true for organisation X:
  * - User is a visitor for X
  * - User is a volunteer for X
- * - User is a admin for a community business which is owned by organisation
- *   (funding-body) X
  *
  * Assumptions:
  * - This route pre-requisite is run _AFTER_ the organisation in question
  *   is fetched and placed in the `pre` object under one of the following keys:
  *   > organisation
  *   > communityBusiness
- *   > fundingBody
  */
 import * as Hapi from '@hapi/hapi';
 import { Organisation, CommunityBusiness } from '../../../models';

--- a/api/src/api/v1/prerequisites/is_parent_organisation.ts
+++ b/api/src/api/v1/prerequisites/is_parent_organisation.ts
@@ -25,7 +25,11 @@ import { Credentials as StandardCredentials } from '../../../auth/strategies/sta
 import { RoleEnum } from '../../../models/types';
 
 
-const getOrg = async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
+interface Request extends Hapi.Request {
+  params: { organisationId?: string };
+}
+
+const getOrg = async (request: Request, h: Hapi.ResponseToolkit) => {
   const { pre } = request;
 
   if ('organisation' in pre) {
@@ -40,7 +44,7 @@ const getOrg = async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
   return getOrganisation(request, h);
 };
 
-export default async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
+export default async (request: Request, h: Hapi.ResponseToolkit) => {
   const { server: { app: { knex } } } = request;
   const { user } = StandardCredentials.fromRequest(request);
 

--- a/api/src/api/v1/prerequisites/require_child_organisation.ts
+++ b/api/src/api/v1/prerequisites/require_child_organisation.ts
@@ -5,8 +5,6 @@
  * which is actually a "child" entity.
  *
  * Conditions under which this is true for organisation X:
- * - User is an admin for a funding body which owns at least
- *   one funding programme of which X is a member
  * - User is a Twine admin
  *
  */

--- a/api/src/api/v1/prerequisites/require_child_organisation.ts
+++ b/api/src/api/v1/prerequisites/require_child_organisation.ts
@@ -1,0 +1,26 @@
+/*
+ * "organisations_details-child" route pre-requisite
+ *
+ * Determines if the authenticated user is trying to access an organisation
+ * which is actually a "child" entity.
+ *
+ * Conditions under which this is true for organisation X:
+ * - User is an admin for a funding body which owns at least
+ *   one funding programme of which X is a member
+ * - User is a Twine admin
+ *
+ */
+import * as Hapi from '@hapi/hapi';
+import * as Boom from '@hapi/boom';
+import isChildOrganisation from './is_child_organisation';
+
+
+export default async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
+  const isChild = await isChildOrganisation(request, h)
+
+  if (!isChild) {
+    throw Boom.forbidden();
+  }
+
+  return true;
+};

--- a/api/src/api/v1/prerequisites/require_child_user.ts
+++ b/api/src/api/v1/prerequisites/require_child_user.ts
@@ -9,9 +9,6 @@
  * - User X is an admin for a community business for which user Y is a VISITOR
  * - User X is an admin for a community business for which user Y is a VOLUNTEER
  * - User X is a Twine admin
- *
- * NOTE: Funding body admins should not be allowed to access user information of
- *       VISITOR or VOLUNTEER users at child community-businesses for GDPR reasons
  */
 import * as Hapi from '@hapi/hapi';
 import * as Boom from '@hapi/boom';

--- a/api/src/api/v1/prerequisites/require_child_user.ts
+++ b/api/src/api/v1/prerequisites/require_child_user.ts
@@ -1,0 +1,29 @@
+/*
+ * "user_details-child" route pre-requisite
+ *
+ * Determines if the authenticated user is trying to access an user
+ * which is actually a "child" entity.
+ *
+ * Conditions under which this is true for user X attemptying to access:
+ * user Y
+ * - User X is an admin for a community business for which user Y is a VISITOR
+ * - User X is an admin for a community business for which user Y is a VOLUNTEER
+ * - User X is a Twine admin
+ *
+ * NOTE: Funding body admins should not be allowed to access user information of
+ *       VISITOR or VOLUNTEER users at child community-businesses for GDPR reasons
+ */
+import * as Hapi from '@hapi/hapi';
+import * as Boom from '@hapi/boom';
+import isChildUser from './is_child_user';
+
+
+export default async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
+  const isChild = await isChildUser(request, h)
+
+  if (!isChild) {
+    throw Boom.forbidden();
+  }
+
+  return true;
+};

--- a/api/src/api/v1/prerequisites/require_child_user.ts
+++ b/api/src/api/v1/prerequisites/require_child_user.ts
@@ -6,8 +6,8 @@
  *
  * Conditions under which this is true for user X attemptying to access:
  * user Y
- * - User X is an admin for a community business for which user Y is a VISITOR
- * - User X is an admin for a community business for which user Y is a VOLUNTEER
+ * - User X is a CB_ADMIN for a community business for which user Y is a VISITOR
+ * - User X is a CB_ADMIN for a community business for which user Y is a VOLUNTEER
  * - User X is a Twine admin
  */
 import * as Hapi from '@hapi/hapi';

--- a/api/src/api/v1/prerequisites/require_parent_organisation.ts
+++ b/api/src/api/v1/prerequisites/require_parent_organisation.ts
@@ -7,15 +7,12 @@
  * Conditions under which this is true for organisation X:
  * - User is a visitor for X
  * - User is a volunteer for X
- * - User is a admin for a community business which is owned by organisation
- *   (funding-body) X
  *
  * Assumptions:
  * - This route pre-requisite is run _AFTER_ the organisation in question
  *   is fetched and placed in the `pre` object under one of the following keys:
  *   > organisation
  *   > communityBusiness
- *   > fundingBody
  */
 import * as Hapi from '@hapi/hapi';
 import * as Boom from '@hapi/boom';

--- a/api/src/api/v1/prerequisites/require_parent_organisation.ts
+++ b/api/src/api/v1/prerequisites/require_parent_organisation.ts
@@ -1,0 +1,32 @@
+/*
+ * "organisations_details-parent" route pre-requisite
+ *
+ * Determines if the authenticated user is trying to access an organisation
+ * which is actually a "parent" entity.
+ *
+ * Conditions under which this is true for organisation X:
+ * - User is a visitor for X
+ * - User is a volunteer for X
+ * - User is a admin for a community business which is owned by organisation
+ *   (funding-body) X
+ *
+ * Assumptions:
+ * - This route pre-requisite is run _AFTER_ the organisation in question
+ *   is fetched and placed in the `pre` object under one of the following keys:
+ *   > organisation
+ *   > communityBusiness
+ *   > fundingBody
+ */
+import * as Hapi from '@hapi/hapi';
+import * as Boom from '@hapi/boom';
+import isParentOrganisation from './is_parent_organisation';
+
+export default async (request: Hapi.Request, h: Hapi.ResponseToolkit) => {
+  const isParent = await isParentOrganisation(request, h)
+
+  if (!isParent) {
+    throw Boom.forbidden();
+  }
+
+  return true;
+};

--- a/api/src/api/v1/users/put.ts
+++ b/api/src/api/v1/users/put.ts
@@ -16,7 +16,7 @@ import {
   response
 } from './schema';
 import { Api } from '../types/api';
-import { isChildUser } from '../prerequisites';
+import { requireChildUser } from '../prerequisites';
 import { Credentials as StandardCredentials } from '../../../auth/strategies/standard';
 
 
@@ -91,7 +91,7 @@ const routes: [
     path: '/users/{userId}',
     options: {
       description: `
-        Update child user\'s details;
+        Update child user's details;
         NOTE: "PUT /community-businesses/:id/visitors/:id" offers similar functionality
       `,
       auth: {
@@ -121,21 +121,14 @@ const routes: [
         },
       },
       response: { schema: response },
-      pre: [
-        { method: isChildUser, assign: 'isChild' },
-      ],
+      pre: [requireChildUser],
     },
     handler: async (request, h) => {
       const {
         server: { app: { knex } },
         payload,
-        pre: { isChild },
         params: { userId },
       } = request;
-
-      if (!isChild) {
-        return Boom.forbidden('Insufficient permission to access this resource');
-      }
 
       const changeset = { ...payload };
 

--- a/api/src/api/v1/users/volunteers/delete.ts
+++ b/api/src/api/v1/users/volunteers/delete.ts
@@ -22,9 +22,7 @@ const routes: [Api.Users.Volunteers.Id.DELETE.Route] = [
         params: { userId: id },
       },
       response: { schema: response },
-      pre: [
-        { method: requireSiblingUser, assign: 'requireSibling' },
-      ],
+      pre: [requireSiblingUser],
     },
     handler: async (request, h) => {
       const { server: { app: { knex } }, params: { userId } } = request;

--- a/api/src/api/v1/users/volunteers/get.ts
+++ b/api/src/api/v1/users/volunteers/get.ts
@@ -22,9 +22,7 @@ const routes: [Api.Users.Volunteers.Id.GET.Route] = [
         params: { userId: id },
       },
       response: { schema: response },
-      pre: [
-        { method: requireSiblingUser, assign: 'requireSibling' },
-      ],
+      pre: [requireSiblingUser],
     },
     handler: async (request, h) => {
       const { server: { app: { knex } }, params: { userId } } = request;

--- a/api/src/api/v1/users/volunteers/put.ts
+++ b/api/src/api/v1/users/volunteers/put.ts
@@ -48,9 +48,7 @@ const routes: [Api.Users.Volunteers.Id.PUT.Route] = [
         },
       },
       response: { schema: response },
-      pre: [
-        { method: requireSiblingUser, assign: 'isSibling' },
-      ],
+      pre: [requireSiblingUser],
     },
     handler: async (request, h) => {
       const { server: { app: { knex } }, params: { userId }, payload } = request;


### PR DESCRIPTION
fixes TwinePlatform/twine-api#132

### Changes
- Add `requireTHING` pre-requisites that fail if `isTHING` pre-req returns false

### Testing Requirements
N/A just a refactor

### Release Requirements
N/A

### Manual Deployment
- API
