### PR TITLE
🐛 fix on-hover bug

### DIFF
--- a/dashboard-app/src/features/dashboard/components/StackedBarChart/Chart.tsx
+++ b/dashboard-app/src/features/dashboard/components/StackedBarChart/Chart.tsx
@@ -48,6 +48,7 @@ const HideableTextOverlay = styled.div<{ isVisible: boolean }>`
   height: 100%;
   width: 100%;
   padding: 10rem 0;
+  z-index: ${(props) => props.isVisible ? 1 : -1};
 
   ${MediaQueriesEnum.landscapeTablet} {
     padding: 8rem 0;


### PR DESCRIPTION
fixes #340 

### Changes
- The text overlay broke the on-hover -- use `z-index` to fix it

### Testing Requirements
- [x] Dashboard
  - Hover over charts -- see if tooltips appear

### Release Requirements
Release when ready

### Manual Deployment
- Dashboard