### PR TITLE
✨ Add toggle between projects/activities to dashboard

### DIFF
--- a/dashboard-app/src/App.tsx
+++ b/dashboard-app/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, SetStateAction, Dispatch } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Route, Switch, BrowserRouter, withRouter } from 'react-router-dom';
 
@@ -18,6 +18,8 @@ import Navbar from './features/navigation/Navbar';
 import Footer from './lib/ui/components/Footer';
 import { ColoursEnum, Fonts } from './lib/ui/design_system';
 import { DurationUnitEnum } from './types';
+import { DashboardContext } from './features/dashboard/context';
+
 
 /*
  * Styles
@@ -36,18 +38,8 @@ const Content = styled.div`
 
 
 /*
- * Context
- */
-type Context = {
-  unit: DurationUnitEnum;
-  setUnit: Dispatch<SetStateAction<DurationUnitEnum>>;
-};
-export const DashboardContext = createContext<Context>({ unit: DurationUnitEnum.HOURS, setUnit: () => {} });
-
-/*
  * Helpers
  */
-
 
 const DashboardRoutes = () => {
   const [unit, setUnit] = useState(DurationUnitEnum.HOURS);

--- a/dashboard-app/src/features/dashboard/ByActivity/__tests__/index.test.ts
+++ b/dashboard-app/src/features/dashboard/ByActivity/__tests__/index.test.ts
@@ -3,7 +3,7 @@ import MockAdapter from 'axios-mock-adapter';
 import { renderWithHistory } from '../../../../lib/util/tests';
 import { axios } from '../../../../lib/api';
 import { logs, users, activities } from '../../__data__/api_data';
-import ByActivity from '../../ByActivity';
+import ByActivity from '..';
 import 'jest-dom/extend-expect';
 
 

--- a/dashboard-app/src/features/dashboard/ByActivity/index.tsx
+++ b/dashboard-app/src/features/dashboard/ByActivity/index.tsx
@@ -19,7 +19,7 @@ import { getTitleForDayPicker } from '../util';
 import { useErrors } from '../../../lib/hooks/useErrors';
 import { TitlesCopy } from '../copy/titles';
 import { useOrderable } from '../hooks/useOrderable';
-import { DashboardContext } from '../../../App';
+import { DashboardContext } from '../context';
 
 
 /**

--- a/dashboard-app/src/features/dashboard/ByProject/ProjectTabs.tsx
+++ b/dashboard-app/src/features/dashboard/ByProject/ProjectTabs.tsx
@@ -9,7 +9,7 @@ import StackedBarChart from '../components/StackedBarChart/index';
 import { LegendData } from '../components/StackedBarChart/types';
 import { TitleString } from '../components/Title';
 import { Orderable } from '../hooks/useOrderable';
-import { DashboardContext } from '../../../App';
+import { DashboardContext } from '../context';
 
 
 /*

--- a/dashboard-app/src/features/dashboard/ByProject/ProjectTabs.tsx
+++ b/dashboard-app/src/features/dashboard/ByProject/ProjectTabs.tsx
@@ -23,6 +23,7 @@ interface Props {
   title: TitleString;
   legendData: LegendData;
   setLegendData: React.Dispatch<React.SetStateAction<LegendData>>;
+  activeData: string;
 }
 
 
@@ -38,6 +39,7 @@ const ProjectTabs: FunctionComponent<Props> = (props) => {
     legendData,
     setLegendData,
     orderable,
+    activeData,
   } = props;
 
   const { unit } = useContext(DashboardContext);
@@ -52,7 +54,7 @@ const ProjectTabs: FunctionComponent<Props> = (props) => {
                 setLegendData={setLegendData}
                 title={title}
                 data={data}
-                xAxisTitle={'Months'}
+                xAxisTitle={activeData}
                 yAxisTitle={`Volunteer ${unit}`}
                 defaultSelection={true}
               />

--- a/dashboard-app/src/features/dashboard/ByProject/__tests__/index.test.ts
+++ b/dashboard-app/src/features/dashboard/ByProject/__tests__/index.test.ts
@@ -1,0 +1,113 @@
+import { cleanup, waitForElement, fireEvent } from 'react-testing-library';
+import MockAdapter from 'axios-mock-adapter';
+import MockDate from 'mockdate';
+import { renderWithHistory } from '../../../../lib/util/tests';
+import { axios } from '../../../../lib/api';
+import { logs, activities, projects } from '../../__data__/api_data';
+import ByProject from '..';
+import 'jest-dom/extend-expect';
+
+
+jest.mock('react-chartjs-2', () => ({ __esModule: true, default: () => null }));
+
+
+describe('By Project Page', () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    MockDate.set('2019-06-30');
+    mock = new MockAdapter(axios);
+  });
+
+  afterEach(cleanup);
+
+  afterAll(() => {
+    MockDate.reset();
+  });
+
+  describe('Table view', () => {
+    test('Display Title', async () => {
+      expect.assertions(2);
+
+      mock.onGet('/community-businesses/me/volunteer-logs').reply(200, { result: [] });
+
+      const tools = renderWithHistory(ByProject);
+      const tableTab = await waitForElement(() => tools.getByText('Table', { exact: true }));
+      fireEvent.click(tableTab);
+
+      const [title, message] = await waitForElement(() => [
+        tools.getByText('Projects', { exact: false }),
+        tools.getByText('AVAILABLE', { exact: false }),
+      ]);
+
+      expect(title).toHaveTextContent('Projects');
+      expect(message).toHaveTextContent('NO DATA AVAILABLE');
+    });
+
+    test('Render data to table', async () => {
+      expect.assertions(2);
+
+      mock.onGet('/community-businesses/me/volunteer-logs').reply(200, { result: logs });
+      mock.onGet('/volunteer-activities').reply(200, { result: activities });
+      mock.onGet('/community-businesses/me/volunteers/projects').reply(200, { result: projects });
+
+      const tools = renderWithHistory(ByProject);
+      const tableTab = await waitForElement(() => tools.getByText('Table', { exact: true }));
+      fireEvent.click(tableTab);
+
+      const [firstHeader] = await waitForElement(() => [
+        tools.getByText('↑', { exact: false }),
+        tools.getByText('Total Hours', { exact: true }),
+        tools.getByText('Cafe', { exact: true }),
+        tools.getByText('Running away', { exact: true }),
+      ]);
+
+      await waitForElement(() => [
+        tools.getByText('General', { exact: true }),
+        tools.getByText('Project 1', { exact: true }),
+      ]);
+
+      await waitForElement(() => tools.getByText('Totals', { exact: true }));
+
+      const rows = await waitForElement(() => tools.getAllByTestId('data-table-row'));
+
+      expect(firstHeader).toHaveTextContent('↑ Project');
+      expect(rows[0]).toHaveTextContent('General2.332.330');
+    });
+
+    test('Toggle between projects and activities', async () => {
+      expect.assertions(3);
+
+      mock.onGet('/community-businesses/me/volunteer-logs').reply(200, { result: logs });
+      mock.onGet('/volunteer-activities').reply(200, { result: activities });
+      mock.onGet('/community-businesses/me/volunteers/projects').reply(200, { result: projects });
+
+      const tools = renderWithHistory(ByProject);
+      const tableTab = await waitForElement(() => tools.getByText('Table', { exact: true }));
+      const projActToggle = await waitForElement(() => tools.getByText('Activities', { exact: true }));
+      fireEvent.click(tableTab);
+      fireEvent.click(projActToggle);
+
+      const [firstHeader] = await waitForElement(() => [
+        tools.getByText('↑', { exact: false }),
+        tools.getByText('Total Hours', { exact: true }),
+        tools.getByText('General', { exact: true }),
+        tools.getByText('Project 1', { exact: true })
+      ]);
+
+      await waitForElement(() => [
+        tools.getByText('Cafe', { exact: true }),
+        tools.getByText('Running away', { exact: true })
+      ]);
+
+      await waitForElement(() => tools.getByText('Totals', { exact: true }));
+
+      const rows = await waitForElement(() => tools.getAllByTestId('data-table-row'));
+
+      expect(firstHeader).toHaveTextContent('↑ Activity');
+      expect(rows[0]).toHaveTextContent('Cafe5.662.333.330');
+      expect(rows[1]).toHaveTextContent('Running away1.3301.330');
+    });
+  });
+
+});

--- a/dashboard-app/src/features/dashboard/ByProject/__tests__/index.test.ts
+++ b/dashboard-app/src/features/dashboard/ByProject/__tests__/index.test.ts
@@ -105,8 +105,8 @@ describe('By Project Page', () => {
       const rows = await waitForElement(() => tools.getAllByTestId('data-table-row'));
 
       expect(firstHeader).toHaveTextContent('↑ Activity');
-      expect(rows[0]).toHaveTextContent('Cafe5.662.333.330');
-      expect(rows[1]).toHaveTextContent('Running away1.3301.330');
+      expect(rows[0]).toHaveTextContent('Cafe5.663.332.33');
+      expect(rows[1]).toHaveTextContent('Running away1.331.330');
     });
   });
 

--- a/dashboard-app/src/features/dashboard/ByProject/datePickerConstraints.ts
+++ b/dashboard-app/src/features/dashboard/ByProject/datePickerConstraints.ts
@@ -6,43 +6,35 @@ import { DateRangePickerConstraint, MIN_DATE } from '../components/DatePicker/ty
 // - min from: 01 Jan 2017
 // - max from: now
 //
-// - default from: 11 months ago
+// - default from: 30 days ago
 // - default to: now
 //
 // - validate:
 //   - from:
 //     - (from < to) || from
-//     - (to - from <= 11 months) || from
 //   - to:
 //     - (from < to) || from
-//     - (to - from <= 11 months) || from + 11 months
 
 
 const TimeConstraints: DateRangePickerConstraint = {
   from: {
     min: () => MIN_DATE.toDate(),
-    max: () => moment().startOf('month').toDate(),
-    default: () => moment().subtract(11, 'months').startOf('month').toDate(),
-    validate: (_from, _to) => moment(_from).startOf('month').toDate(),
+    max: () => moment().endOf('day').toDate(),
+    default: () => moment().subtract(30, 'days').startOf('day').toDate(),
+    validate: (_from, _to) => moment(_from).startOf('day').toDate(),
   },
 
   to: {
-    min: (from, to) => moment.max(MIN_DATE, moment(from)).endOf('month').toDate(),
-    max: (from, to) => moment.min(moment(), moment(from).add(11, 'months').endOf('month')).toDate(),
-    default: () => moment().endOf('month').toDate(),
+    min: (from, to) => moment.max(MIN_DATE, moment(from)).startOf('day').toDate(),
+    max: () => moment().endOf('day').toDate(),
+    default: () => moment().endOf('day').toDate(),
     validate: (_from, _to) => {
-      const from = moment(_from).startOf('month');
-      const to = moment(_to).endOf('month');
+      const from = moment(_from).startOf('day');
+      const to = moment(_to).endOf('day');
 
-      if (from.isAfter(to)) {
-        return from.endOf('month').toDate();
-      }
-
-      if (to.diff(from, 'months') > 11) {
-        return from.add(11, 'months').endOf('month').toDate();
-      }
-
-      return to.toDate();
+      return from.isAfter(to)
+        ? from.endOf('day').toDate()
+        : to.toDate();
     },
   },
 };

--- a/dashboard-app/src/features/dashboard/ByProject/index.tsx
+++ b/dashboard-app/src/features/dashboard/ByProject/index.tsx
@@ -119,21 +119,8 @@ const ByProjects: FunctionComponent<RouteComponentProps> = () => {
             onFromDateChange={setFromDate}
             onToDateChange={setToDate}
             onDownloadClick={downloadAsCsv}
+            customToggle={<Toggle active={activeData} onChange={setActiveData} />}
           />
-        </Col>
-      </Row>
-      <Row>
-        <Col xs={12}>
-          <Card>
-            <WrapperOne>
-              <Toggle active={activeData} onChange={setActiveData} />
-            </WrapperOne>
-            <WrapperTwo>
-              <Span>
-                Select whether time should be aggregated against projects or activities
-              </Span>
-            </WrapperTwo>
-          </Card>
         </Col>
       </Row>
       <Errors errors={errors} />

--- a/dashboard-app/src/features/dashboard/ByProject/index.tsx
+++ b/dashboard-app/src/features/dashboard/ByProject/index.tsx
@@ -7,7 +7,6 @@ import DatePickerConstraints from './datePickerConstraints';
 import UtilityBar from '../components/UtilityBar';
 import { FullScreenBeatLoader } from '../../../lib/ui/components/Loaders';
 import { H1 } from '../../../lib/ui/components/Headings';
-import { Span } from '../../../lib/ui/components/Typography';
 import ProjectActivityToggle from '../components/ProjectActivityToggle';
 import { aggregatedToTableData, TableData } from '../dataManipulation/aggregatedToTableData';
 import { downloadCsv } from '../dataManipulation/downloadCsv';
@@ -21,7 +20,6 @@ import { useErrors } from '../../../lib/hooks/useErrors';
 import { TitlesCopy } from '../copy/titles';
 import { useOrderable } from '../hooks/useOrderable';
 import { DashboardContext } from '../context';
-import _Card from '../../../lib/ui/components/Card';
 
 
 /**
@@ -29,21 +27,6 @@ import _Card from '../../../lib/ui/components/Card';
  */
 const Container = styled(Grid)``;
 
-const Toggle = styled(ProjectActivityToggle)`
-  margin-right: 1rem;
-`;
-
-const Card = styled(_Card)`
-  background-color: ${ColoursEnum.white};
-`;
-
-const WrapperOne = styled.div`
-  display: inline-block;
-  margin: 1rem;
-`;
-const WrapperTwo = styled.div`
-  display: inline-block;
-`;
 
 /**
  * Helpers
@@ -119,7 +102,7 @@ const ByProjects: FunctionComponent<RouteComponentProps> = () => {
             onFromDateChange={setFromDate}
             onToDateChange={setToDate}
             onDownloadClick={downloadAsCsv}
-            customToggle={<Toggle active={activeData} onChange={setActiveData} />}
+            customToggle={<ProjectActivityToggle active={activeData} onChange={setActiveData} />}
           />
         </Col>
       </Row>

--- a/dashboard-app/src/features/dashboard/ByProject/index.tsx
+++ b/dashboard-app/src/features/dashboard/ByProject/index.tsx
@@ -7,6 +7,7 @@ import DatePickerConstraints from './datePickerConstraints';
 import UtilityBar from '../components/UtilityBar';
 import { FullScreenBeatLoader } from '../../../lib/ui/components/Loaders';
 import { H1 } from '../../../lib/ui/components/Headings';
+import ProjectActivityToggle from '../components/ProjectActivityToggle';
 import { aggregatedToTableData, TableData } from '../dataManipulation/aggregatedToTableData';
 import { downloadCsv } from '../dataManipulation/downloadCsv';
 import { ColoursEnum } from '../../../lib/ui/design_system';
@@ -18,13 +19,16 @@ import { LegendData } from '../components/StackedBarChart/types';
 import { useErrors } from '../../../lib/hooks/useErrors';
 import { TitlesCopy } from '../copy/titles';
 import { useOrderable } from '../hooks/useOrderable';
-import { DashboardContext } from '../../../App';
+import { DashboardContext } from '../context';
 
 
 /**
  * Styles
  */
-const Container = styled(Grid)`
+const Container = styled(Grid)``;
+
+const Toggle = styled(ProjectActivityToggle)`
+  margin-right: 1rem;
 `;
 
 
@@ -36,24 +40,25 @@ const initTableData = { headers: [], rows: [] };
 /**
  * Component
  */
-const ByTime: FunctionComponent<RouteComponentProps> = () => {
+const ByProjects: FunctionComponent<RouteComponentProps> = () => {
   const { unit } = useContext(DashboardContext);
+  const [activeData, setActiveData] = useState<'Projects' | 'Activities'>('Projects');
   const [fromDate, setFromDate] = useState<Date>(DatePickerConstraints.from.default());
   const [toDate, setToDate] = useState<Date>(DatePickerConstraints.to.default());
   const [tableData, setTableData] = useState<TableData>(initTableData);
   const [legendData, setLegendData] = useState<LegendData>([]);
-  const { data, loading, error, activities } =
-    useAggregateDataByProject({ from: fromDate, to: toDate });
+  const { data, loading, error, yData } =
+    useAggregateDataByProject({ from: fromDate, to: toDate, independentVar: activeData });
 
   // set and clear errors on response
   const [errors, setErrors] = useErrors(error, data);
 
   // manipulate data for table
   useEffect(() => {
-    if (!loading && data && activities) {
-      setTableData(aggregatedToTableData({ data, unit, yData: activities }));
+    if (!loading && data && yData) {
+      setTableData(aggregatedToTableData({ data, unit, yData }));
     }
-  }, [data, unit, loading, activities]);
+  }, [data, unit, loading, yData]);
 
   // get sorting state values
   const { orderable, onChangeOrderable } = useOrderable({
@@ -100,6 +105,7 @@ const ByTime: FunctionComponent<RouteComponentProps> = () => {
             onFromDateChange={setFromDate}
             onToDateChange={setToDate}
             onDownloadClick={downloadAsCsv}
+            customToggle={<Toggle active={activeData} onChange={setActiveData} />}
           />
         </Col>
       </Row>
@@ -113,5 +119,5 @@ const ByTime: FunctionComponent<RouteComponentProps> = () => {
   );
 };
 
-export default withRouter(ByTime);
+export default withRouter(ByProjects);
 

--- a/dashboard-app/src/features/dashboard/ByProject/index.tsx
+++ b/dashboard-app/src/features/dashboard/ByProject/index.tsx
@@ -88,6 +88,7 @@ const ByProjects: FunctionComponent<RouteComponentProps> = () => {
     legendData,
     setLegendData,
     orderable,
+    activeData: activeData === 'Activities' ? 'Projects' : 'Activities',
   };
 
   return (

--- a/dashboard-app/src/features/dashboard/ByProject/index.tsx
+++ b/dashboard-app/src/features/dashboard/ByProject/index.tsx
@@ -101,7 +101,7 @@ const ByProjects: FunctionComponent<RouteComponentProps> = () => {
       <Row center="xs">
         <Col xs={12}>
           <UtilityBar
-            dateFilter="month"
+            dateFilter="day"
             datePickerConstraint={DatePickerConstraints}
             onFromDateChange={setFromDate}
             onToDateChange={setToDate}

--- a/dashboard-app/src/features/dashboard/ByProject/index.tsx
+++ b/dashboard-app/src/features/dashboard/ByProject/index.tsx
@@ -7,6 +7,7 @@ import DatePickerConstraints from './datePickerConstraints';
 import UtilityBar from '../components/UtilityBar';
 import { FullScreenBeatLoader } from '../../../lib/ui/components/Loaders';
 import { H1 } from '../../../lib/ui/components/Headings';
+import { Span } from '../../../lib/ui/components/Typography';
 import ProjectActivityToggle from '../components/ProjectActivityToggle';
 import { aggregatedToTableData, TableData } from '../dataManipulation/aggregatedToTableData';
 import { downloadCsv } from '../dataManipulation/downloadCsv';
@@ -20,6 +21,7 @@ import { useErrors } from '../../../lib/hooks/useErrors';
 import { TitlesCopy } from '../copy/titles';
 import { useOrderable } from '../hooks/useOrderable';
 import { DashboardContext } from '../context';
+import _Card from '../../../lib/ui/components/Card';
 
 
 /**
@@ -31,6 +33,17 @@ const Toggle = styled(ProjectActivityToggle)`
   margin-right: 1rem;
 `;
 
+const Card = styled(_Card)`
+  background-color: ${ColoursEnum.white};
+`;
+
+const WrapperOne = styled.div`
+  display: inline-block;
+  margin: 1rem;
+`;
+const WrapperTwo = styled.div`
+  display: inline-block;
+`;
 
 /**
  * Helpers
@@ -106,8 +119,21 @@ const ByProjects: FunctionComponent<RouteComponentProps> = () => {
             onFromDateChange={setFromDate}
             onToDateChange={setToDate}
             onDownloadClick={downloadAsCsv}
-            customToggle={<Toggle active={activeData} onChange={setActiveData} />}
           />
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={12}>
+          <Card>
+            <WrapperOne>
+              <Toggle active={activeData} onChange={setActiveData} />
+            </WrapperOne>
+            <WrapperTwo>
+              <Span>
+                Select whether time should be aggregated against projects or activities
+              </Span>
+            </WrapperTwo>
+          </Card>
         </Col>
       </Row>
       <Errors errors={errors} />

--- a/dashboard-app/src/features/dashboard/ByProject/useAggregateDataByProject.ts
+++ b/dashboard-app/src/features/dashboard/ByProject/useAggregateDataByProject.ts
@@ -1,4 +1,5 @@
 import { DependencyList, useEffect, useState } from 'react';
+import { assoc } from 'ramda';
 import { useBatchRequest } from '../../../lib/hooks';
 import { CommunityBusinesses } from '../../../lib/api';
 import {
@@ -12,11 +13,13 @@ import { tableType } from '../dataManipulation/tableType';
 interface UseAggregatedDataParams {
   from: Date;
   to: Date;
+  independentVar: 'Projects' | 'Activities';
   updateOn?: DependencyList;
 }
 
-export default ({ from, to, updateOn = [] }: UseAggregatedDataParams) => {
+export default ({ from, to, updateOn = [], independentVar }: UseAggregatedDataParams) => {
   const [aggregatedData, setAggregatedData] = useState<AggregatedData>();
+  const [yData, setYData] = useState();
 
   const {
     loading,
@@ -27,7 +30,7 @@ export default ({ from, to, updateOn = [] }: UseAggregatedDataParams) => {
       {
         ...CommunityBusinesses.configs.getLogs,
         params: { since: from, until: to },
-        transformResponse: [(res: any) => res.result],
+        transformResponse: [(res: any) => res.result.map((log: any) => assoc('project', log.project || 'General', log))],
       },
       {
         ...CommunityBusinesses.configs.getVolunteerProjects,
@@ -46,15 +49,19 @@ export default ({ from, to, updateOn = [] }: UseAggregatedDataParams) => {
       return;
     }
 
-    const data = logsToAggregatedData({
-      logs: logsData.data,
-      tableType: tableType.ActivityByProject,
-      xData: projectsData.data,
-      yData: activitiesData.data,
-    });
+    const _yData = independentVar === 'Activities'
+      ? projectsData.data.concat({ id: -1, name: 'null' })
+      : activitiesData.data
 
+    const opts = independentVar === 'Activities'
+      ? { tableType: tableType.ProjectByActivity, xData: activitiesData.data, yData: _yData }
+      : { tableType: tableType.ActivityByProject, xData: projectsData.data.concat({ id: -1, name: 'null' }), yData: _yData }
+
+    const data = logsToAggregatedData({ logs: logsData.data, ...opts });
+
+    setYData(_yData);
     setAggregatedData(data);
-  }, [logsData, activitiesData, error, loading, projectsData]);
+  }, [logsData, activitiesData, error, loading, projectsData, independentVar]);
 
 
   if (loading) {
@@ -67,7 +74,7 @@ export default ({ from, to, updateOn = [] }: UseAggregatedDataParams) => {
 
   } else {
 
-    return { loading, data: aggregatedData, error, activities: activitiesData.data };
+    return { loading, data: aggregatedData, error, yData };
 
   }
 };

--- a/dashboard-app/src/features/dashboard/ByProject/useAggregateDataByProject.ts
+++ b/dashboard-app/src/features/dashboard/ByProject/useAggregateDataByProject.ts
@@ -34,7 +34,11 @@ export default ({ from, to, updateOn = [], independentVar }: UseAggregatedDataPa
       },
       {
         ...CommunityBusinesses.configs.getVolunteerProjects,
-        transformResponse: [(res: any) => res.result.map(({ id, name }: IdAndName) => ({ id, name }))],
+        transformResponse: [
+          (res: any) => res.result
+            .map(({ id, name }: IdAndName) => ({ id, name }))
+            .concat({ id: -1, name: 'General' })
+        ],
       },
       {
         ...CommunityBusinesses.configs.getVolunteerActivities,
@@ -50,12 +54,12 @@ export default ({ from, to, updateOn = [], independentVar }: UseAggregatedDataPa
     }
 
     const _yData = independentVar === 'Activities'
-      ? projectsData.data.concat({ id: -1, name: 'null' })
+      ? projectsData.data
       : activitiesData.data
 
     const opts = independentVar === 'Activities'
       ? { tableType: tableType.ProjectByActivity, xData: activitiesData.data, yData: _yData }
-      : { tableType: tableType.ActivityByProject, xData: projectsData.data.concat({ id: -1, name: 'null' }), yData: _yData }
+      : { tableType: tableType.ActivityByProject, xData: projectsData.data, yData: _yData }
 
     const data = logsToAggregatedData({ logs: logsData.data, ...opts });
 

--- a/dashboard-app/src/features/dashboard/ByTime/TimeTabs.tsx
+++ b/dashboard-app/src/features/dashboard/ByTime/TimeTabs.tsx
@@ -9,7 +9,7 @@ import StackedBarChart from '../components/StackedBarChart/index';
 import { LegendData } from '../components/StackedBarChart/types';
 import { TitleString } from '../components/Title';
 import { Orderable } from '../hooks/useOrderable';
-import { DashboardContext } from '../../../App';
+import { DashboardContext } from '../context';
 
 
 /*

--- a/dashboard-app/src/features/dashboard/ByTime/__tests__/index.test.ts
+++ b/dashboard-app/src/features/dashboard/ByTime/__tests__/index.test.ts
@@ -4,7 +4,7 @@ import MockDate from 'mockdate';
 import { renderWithHistory } from '../../../../lib/util/tests';
 import { axios } from '../../../../lib/api';
 import { logs, activities } from '../../__data__/api_data';
-import ByTime from '../../ByTime';
+import ByTime from '..';
 import 'jest-dom/extend-expect';
 
 

--- a/dashboard-app/src/features/dashboard/ByTime/index.tsx
+++ b/dashboard-app/src/features/dashboard/ByTime/index.tsx
@@ -18,7 +18,7 @@ import { LegendData } from '../components/StackedBarChart/types';
 import { useErrors } from '../../../lib/hooks/useErrors';
 import { TitlesCopy } from '../copy/titles';
 import { useOrderable } from '../hooks/useOrderable';
-import { DashboardContext } from '../../../App';
+import { DashboardContext } from '../context';
 
 
 /**

--- a/dashboard-app/src/features/dashboard/ByVolunteer/VolunteerTabs.tsx
+++ b/dashboard-app/src/features/dashboard/ByVolunteer/VolunteerTabs.tsx
@@ -10,8 +10,7 @@ import StackedBarChart from '../components/StackedBarChart/index';
 import { LegendData } from '../components/StackedBarChart/types';
 import { TitleString } from '../components/Title';
 import { Orderable } from '../hooks/useOrderable';
-
-import { DashboardContext } from '../../../App';
+import { DashboardContext } from '../context';
 
 /*
  * Types

--- a/dashboard-app/src/features/dashboard/ByVolunteer/__tests__/index.test.ts
+++ b/dashboard-app/src/features/dashboard/ByVolunteer/__tests__/index.test.ts
@@ -4,7 +4,7 @@ import MockDate from 'mockdate';
 import { renderWithHistory } from '../../../../lib/util/tests';
 import { axios } from '../../../../lib/api';
 import { logs, users } from '../../__data__/api_data';
-import ByVolunteer from '../../ByVolunteer';
+import ByVolunteer from '..';
 import 'jest-dom/extend-expect';
 
 

--- a/dashboard-app/src/features/dashboard/ByVolunteer/index.tsx
+++ b/dashboard-app/src/features/dashboard/ByVolunteer/index.tsx
@@ -18,7 +18,7 @@ import { LegendData } from '../components/StackedBarChart/types';
 import { useErrors } from '../../../lib/hooks/useErrors';
 import { TitlesCopy } from '../copy/titles';
 import { useOrderable } from '../hooks/useOrderable';
-import { DashboardContext } from '../../../App';
+import { DashboardContext } from '../context';
 
 
 /**

--- a/dashboard-app/src/features/dashboard/__data__/api_data.ts
+++ b/dashboard-app/src/features/dashboard/__data__/api_data.ts
@@ -4,6 +4,7 @@ export const logs = [
     startedAt: '2018-10-11T10:34:22.001',
     duration: { hours: 2 },
     activity: 'Cafe',
+    project: null,
     userId: 1,
   },
   {
@@ -11,20 +12,23 @@ export const logs = [
     startedAt: '2019-02-11T10:34:22.001',
     duration: { hours: 1, minutes: 20 },
     activity: 'Running away',
+    project: 'Project 1',
     userId: 1,
   },
   {
-    id: 2,
+    id: 3,
     startedAt: '2018-11-11T10:34:22.001',
     duration: { hours: 0, minutes: 20 },
     activity: 'Cafe',
+    project: null,
     userId: 2,
   },
   {
-    id: 2,
+    id: 4,
     startedAt: '2018-12-11T10:34:22.001',
     duration: { hours: 3, minutes: 20 },
     activity: 'Cafe',
+    project: 'Project 1',
     userId: 2,
   },
 ];
@@ -37,4 +41,9 @@ export const users = [
 export const activities = [
   { id: 1, name: 'Cafe' },
   { id: 2, name: 'Running away' },
+];
+
+export const projects = [
+  { id: 1, name: 'General' },
+  { id: 2, name: 'Project 1' },
 ];

--- a/dashboard-app/src/features/dashboard/__data__/api_data.ts
+++ b/dashboard-app/src/features/dashboard/__data__/api_data.ts
@@ -44,6 +44,5 @@ export const activities = [
 ];
 
 export const projects = [
-  { id: 1, name: 'General' },
   { id: 2, name: 'Project 1' },
 ];

--- a/dashboard-app/src/features/dashboard/components/DatePicker/Selector.tsx
+++ b/dashboard-app/src/features/dashboard/components/DatePicker/Selector.tsx
@@ -31,7 +31,7 @@ const Input = styled.input`
   background: transparent;
   color: ${ColoursEnum.black};
   cursor: pointer;
-  font-size: ${Fonts.size.body}
+  font-size: ${Fonts.size.body};
 `;
 
 

--- a/dashboard-app/src/features/dashboard/components/InfoTag.tsx
+++ b/dashboard-app/src/features/dashboard/components/InfoTag.tsx
@@ -1,0 +1,17 @@
+import React, { FunctionComponent } from 'react';
+import styled from 'styled-components';
+import { Span as _Span } from '../../../lib/ui/components/Typography';
+
+
+const Span = styled(_Span)`
+  margin-right: 1rem;
+`;
+
+
+const Info: FunctionComponent<{ title: string }> = ({ title }) => {
+  return (
+    <Span role="img" aria-label="information" title={title}>ⓘ</Span>
+  )
+}
+
+export default Info;

--- a/dashboard-app/src/features/dashboard/components/InfoTag.tsx
+++ b/dashboard-app/src/features/dashboard/components/InfoTag.tsx
@@ -1,16 +1,20 @@
 import React, { FunctionComponent } from 'react';
 import styled from 'styled-components';
+import Tooltip from './Tooltip';
 import { Span as _Span } from '../../../lib/ui/components/Typography';
 
 
 const Span = styled(_Span)`
   margin-right: 1rem;
+  cursor: pointer;
 `;
 
 
 const Info: FunctionComponent<{ title: string }> = ({ title }) => {
   return (
-    <Span role="img" aria-label="information" title={title}>ⓘ</Span>
+    <Tooltip>
+      <Span role="img" aria-label="information" data-tooltip={title}>ⓘ</Span>
+    </Tooltip>
   )
 }
 

--- a/dashboard-app/src/features/dashboard/components/ProjectActivityToggle.tsx
+++ b/dashboard-app/src/features/dashboard/components/ProjectActivityToggle.tsx
@@ -1,5 +1,16 @@
 import React from 'react';
+import styled from 'styled-components';
 import Toggle from './Toggle';
+import { Span as _Span } from '../../../lib/ui/components/Typography';
+import Info from './InfoTag';
+
+
+/**
+ * Styles
+ */
+const Span = styled(_Span)`
+  margin: 0 1rem;
+`;
 
 
 /**
@@ -11,17 +22,22 @@ type ProjectActivityToggleProps = {
   onChange: (u: ProjectOrActivity) => void
 };
 
+
 /**
  * Component
  */
 const ProjectActivityToggle: React.FunctionComponent<ProjectActivityToggleProps> = ({ active, onChange, ...rest }) => (
-  <Toggle
-    {...rest}
-    left="Projects"
-    right="Activities"
-    active={active === 'Projects' ? 'left' : 'right'}
-    onChange={(s) => onChange(s === 'Projects' ? 'Projects' : 'Activities')}
-  />
+  <>
+    <Span>Group by:</Span>
+    <Info title="Choose whether to group time by projects or activities" />
+    <Toggle
+      {...rest}
+      left="Projects"
+      right="Activities"
+      active={active === 'Projects' ? 'left' : 'right'}
+      onChange={(s) => onChange(s === 'Projects' ? 'Projects' : 'Activities')}
+    />
+  </>
 );
 
 export default ProjectActivityToggle;

--- a/dashboard-app/src/features/dashboard/components/ProjectActivityToggle.tsx
+++ b/dashboard-app/src/features/dashboard/components/ProjectActivityToggle.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Toggle from './Toggle';
+
+
+/**
+ * Types
+ */
+type ProjectOrActivity = 'Projects' | 'Activities';
+type ProjectActivityToggleProps = {
+  active: ProjectOrActivity
+  onChange: (u: ProjectOrActivity) => void
+};
+
+/**
+ * Component
+ */
+const ProjectActivityToggle: React.FunctionComponent<ProjectActivityToggleProps> = ({ active, onChange, ...rest }) => (
+  <Toggle
+    {...rest}
+    left="Projects"
+    right="Activities"
+    active={active === 'Projects' ? 'left' : 'right'}
+    onChange={(s) => onChange(s === 'Projects' ? 'Projects' : 'Activities')}
+  />
+);
+
+export default ProjectActivityToggle;

--- a/dashboard-app/src/features/dashboard/components/StackedBarChart/index.tsx
+++ b/dashboard-app/src/features/dashboard/components/StackedBarChart/index.tsx
@@ -1,6 +1,8 @@
 import React, { FunctionComponent, useState, useEffect, useCallback, useContext } from 'react';
 import { Row, Col } from 'react-flexbox-grid';
 import { equals } from 'ramda';
+import { reduceValues } from 'twine-util/objects';
+import { Duration } from 'twine-util';
 
 import {
   flipActiveOfAll,
@@ -36,15 +38,18 @@ interface Props {
 /*
  * Helpers
  */
+const isCellDurationZero = (content: string | Duration.Duration) =>
+  typeof content === 'object' ? Duration.equals(content, {}) : true;
 
 const getOverlayText = (data: AggregatedData, legendItemsActive: boolean): [boolean, string] => {
   const noActiveLegendText = data.groupByX === 'Activity'
     ? 'Select an activity to show data'
     : 'Select volunteers to show their hours';
 
-  const dataExists = data.rows.length > 0;
+  const noData = data.rows.length === 0 || data.rows
+    .every((row) => reduceValues((acc, content) => acc && isCellDurationZero(content), true, row))
 
-  if (!dataExists) {
+  if (noData) {
     return [true, 'No data for this range']
   } else if (!legendItemsActive) {
     return [true, noActiveLegendText];

--- a/dashboard-app/src/features/dashboard/components/StackedBarChart/index.tsx
+++ b/dashboard-app/src/features/dashboard/components/StackedBarChart/index.tsx
@@ -15,7 +15,7 @@ import Legend from './Legend/index';
 import Chart from './Chart';
 import { LegendData } from './types';
 import { TitleString } from '../Title';
-import { DashboardContext } from '../../../../App';
+import { DashboardContext } from '../../context';
 
 
 /*

--- a/dashboard-app/src/features/dashboard/components/Toggle.tsx
+++ b/dashboard-app/src/features/dashboard/components/Toggle.tsx
@@ -41,7 +41,7 @@ const Container = styled.div``;
 
 
 const Toggle: React.FunctionComponent<ToggleProps> = (props) => {
-  const { left, right, leftTitle, rightTitle, onChange } = props;
+  const { left, right, leftTitle, rightTitle, onChange, ...rest } = props;
   const [active, setActive] = useState<Side>(props.active || 'left');
 
   const onClick = useCallback((side: Side) => {
@@ -50,7 +50,7 @@ const Toggle: React.FunctionComponent<ToggleProps> = (props) => {
   }, [left, onChange, right]);
 
   return (
-    <Container>
+    <Container {...rest}>
       <Left active={active === 'left'} onClick={() => onClick('left')} title={leftTitle}>
         {left}
       </Left>

--- a/dashboard-app/src/features/dashboard/components/Tooltip.tsx
+++ b/dashboard-app/src/features/dashboard/components/Tooltip.tsx
@@ -1,0 +1,77 @@
+/**
+ * Nicked from https://chrisbracco.com/a-simple-css-tooltip/
+ */
+import React, { FC } from 'react';
+import styled from 'styled-components';
+
+
+const Box = styled.div`
+  & {
+    /* Add this attribute to the element that needs a tooltip */
+    [data-tooltip] {
+      position: relative;
+      z-index: 2;
+      cursor: pointer;
+    }
+
+    /* Hide the tooltip content by default */
+    [data-tooltip]:before,
+    [data-tooltip]:after {
+      visibility: hidden;
+      -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
+      filter: progid: DXImageTransform.Microsoft.Alpha(Opacity=0);
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    /* Position tooltip above the element */
+    [data-tooltip]:before {
+      position: absolute;
+      bottom: 150%;
+      left: 50%;
+      margin-bottom: 5px;
+      margin-left: -80px;
+      padding: 7px;
+      width: 160px;
+      -webkit-border-radius: 3px;
+      -moz-border-radius: 3px;
+      border-radius: 3px;
+      background-color: #000;
+      background-color: hsla(0, 0%, 20%, 0.9);
+      color: #fff;
+      content: attr(data-tooltip);
+      text-align: center;
+      font-size: 14px;
+      line-height: 1.2;
+    }
+
+    /* Triangle hack to make tooltip look like a speech bubble */
+    [data-tooltip]:after {
+      position: absolute;
+      bottom: 150%;
+      left: 50%;
+      margin-left: -5px;
+      width: 0;
+      border-top: 5px solid #000;
+      border-top: 5px solid hsla(0, 0%, 20%, 0.9);
+      border-right: 5px solid transparent;
+      border-left: 5px solid transparent;
+      content: " ";
+      font-size: 0;
+      line-height: 0;
+    }
+
+    /* Show tooltip content on hover */
+    [data-tooltip]:hover:before,
+    [data-tooltip]:hover:after {
+      visibility: visible;
+      -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
+      filter: progid: DXImageTransform.Microsoft.Alpha(Opacity=100);
+      opacity: 1;
+    }
+  }
+`;
+
+const Tooltip: FC = ({ children }) => <Box>{children}</Box>;
+
+export default Tooltip;

--- a/dashboard-app/src/features/dashboard/components/UnitToggle.tsx
+++ b/dashboard-app/src/features/dashboard/components/UnitToggle.tsx
@@ -31,7 +31,7 @@ const UnitToggle: React.FunctionComponent<UnitToggleProps> = (props) => {
   return (
     <>
       <Span>Unit:</Span>
-      <Info title="Eight (8) hours are counted as one (1) day" />
+      <Info title="Display time in units of hours or days (Eight (8) hours are counted as one (1) day)" />
       <Toggle
         left="Hours"
         right="Days"

--- a/dashboard-app/src/features/dashboard/components/UnitToggle.tsx
+++ b/dashboard-app/src/features/dashboard/components/UnitToggle.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import Toggle, { Side } from './Toggle';
 import { DurationUnitEnum } from '../../../types';
-import { DashboardContext } from '../../../App';
+import { DashboardContext } from '../context';
 
 /**
  * Types
@@ -18,15 +18,15 @@ const UnitToggle: React.FunctionComponent<UnitToggleProps> = (props) => {
   const { unit } = useContext(DashboardContext);
   const active: Side = unit === DurationUnitEnum.HOURS ? 'left' : 'right';
   return (
-  <Toggle
-    left="Hours"
-    right="Days"
-    rightTitle="Eight (8) hours are counted as one (1) day"
-    active={active}
-    onChange={(s) =>
-      props.onChange(s === DurationUnitEnum.HOURS ? DurationUnitEnum.HOURS : DurationUnitEnum.DAYS)
-    }
-  />
+    <Toggle
+      left="Hours"
+      right="Days"
+      rightTitle="Eight (8) hours are counted as one (1) day"
+      active={active}
+      onChange={(s) =>
+        props.onChange(s === DurationUnitEnum.HOURS ? DurationUnitEnum.HOURS : DurationUnitEnum.DAYS)
+      }
+    />
   );
 };
 

--- a/dashboard-app/src/features/dashboard/components/UnitToggle.tsx
+++ b/dashboard-app/src/features/dashboard/components/UnitToggle.tsx
@@ -1,12 +1,23 @@
 import React, { useContext } from 'react';
+import styled from 'styled-components';
 import Toggle, { Side } from './Toggle';
 import { DurationUnitEnum } from '../../../types';
 import { DashboardContext } from '../context';
+import { Span as _Span } from '../../../lib/ui/components/Typography';
+import Info from './InfoTag';
+
+
+/**
+ * Styles
+ */
+const Span = styled(_Span)`
+  margin: 0 1rem;
+`;
+
 
 /**
  * Types
  */
-
 type UnitToggleProps = {
   onChange: (u: DurationUnitEnum) => void
 };
@@ -18,15 +29,19 @@ const UnitToggle: React.FunctionComponent<UnitToggleProps> = (props) => {
   const { unit } = useContext(DashboardContext);
   const active: Side = unit === DurationUnitEnum.HOURS ? 'left' : 'right';
   return (
-    <Toggle
-      left="Hours"
-      right="Days"
-      rightTitle="Eight (8) hours are counted as one (1) day"
-      active={active}
-      onChange={(s) =>
-        props.onChange(s === DurationUnitEnum.HOURS ? DurationUnitEnum.HOURS : DurationUnitEnum.DAYS)
-      }
-    />
+    <>
+      <Span>Unit:</Span>
+      <Info title="Eight (8) hours are counted as one (1) day" />
+      <Toggle
+        left="Hours"
+        right="Days"
+        rightTitle="Eight (8) hours are counted as one (1) day"
+        active={active}
+        onChange={(s) =>
+          props.onChange(s === DurationUnitEnum.HOURS ? DurationUnitEnum.HOURS : DurationUnitEnum.DAYS)
+        }
+      />
+    </>
   );
 };
 

--- a/dashboard-app/src/features/dashboard/components/UtilityBar.tsx
+++ b/dashboard-app/src/features/dashboard/components/UtilityBar.tsx
@@ -8,7 +8,6 @@ import { DurationUnitEnum } from '../../../types';
 import { DownloadButton } from '../../../lib/ui/components/Buttons';
 import { DateRangePickerConstraint } from './DatePicker/types';
 import { DashboardContext } from '../context';
-import { Span as _Span } from '../../../lib/ui/components/Typography';
 
 
 /**
@@ -32,10 +31,6 @@ type UtilityBarProps = {
  */
 const MainRow = styled(Row)`
   margin-bottom: 2rem;
-`;
-
-const Span = styled(_Span)`
-  margin-right: 1rem;
 `;
 
 /**
@@ -82,7 +77,7 @@ const UtilityBar: React.FunctionComponent<UtilityBarProps> = (props) => {
 
   return (
     <MainRow middle="xs" start="xs" {...rest}>
-      <Col xs={6}>
+      <Col xs={5}>
         <DatePicker
           type={dateFilter}
           label="From"
@@ -100,11 +95,9 @@ const UtilityBar: React.FunctionComponent<UtilityBarProps> = (props) => {
           maxDate={constraint.to.max(fromDate, toDate)}
         />
       </Col>
-      <Col xs={6}>
+      <Col xs={7}>
         <Row end="xs" middle="xs">
-          <Span>Group by:</Span>
           {customToggle}
-          <Span role="img" aria-label="sheep">ⓘ</Span>
           <UnitToggle onChange={onDisplayUnitChange} />
           <DownloadButton onClick={onDownloadClick}>Download</DownloadButton>
         </Row>

--- a/dashboard-app/src/features/dashboard/components/UtilityBar.tsx
+++ b/dashboard-app/src/features/dashboard/components/UtilityBar.tsx
@@ -7,7 +7,7 @@ import UnitToggle from './UnitToggle';
 import { DurationUnitEnum } from '../../../types';
 import { DownloadButton } from '../../../lib/ui/components/Buttons';
 import { DateRangePickerConstraint } from './DatePicker/types';
-import { DashboardContext } from '../../../App';
+import { DashboardContext } from '../context';
 
 
 /**
@@ -18,6 +18,7 @@ type DateFilterType = 'day' | 'month';
 type UtilityBarProps = {
   dateFilter: DateFilterType
   datePickerConstraint: DateRangePickerConstraint
+  customToggle?: React.ReactElement
   onFromDateChange?: (d: Date) => void
   onToDateChange?: (d: Date) => void
   onUnitChange?: (u: DurationUnitEnum) => void
@@ -43,6 +44,7 @@ const UtilityBar: React.FunctionComponent<UtilityBarProps> = (props) => {
     onToDateChange = () => { },
     onUnitChange = () => { },
     onDownloadClick = () => { },
+    customToggle = null,
     ...rest
   } = props;
 
@@ -95,6 +97,7 @@ const UtilityBar: React.FunctionComponent<UtilityBarProps> = (props) => {
       </Col>
       <Col xs={6}>
         <Row end="xs">
+          {customToggle}
           <UnitToggle onChange={onDisplayUnitChange} />
           <DownloadButton onClick={onDownloadClick}>Download</DownloadButton>
         </Row>

--- a/dashboard-app/src/features/dashboard/components/UtilityBar.tsx
+++ b/dashboard-app/src/features/dashboard/components/UtilityBar.tsx
@@ -8,6 +8,7 @@ import { DurationUnitEnum } from '../../../types';
 import { DownloadButton } from '../../../lib/ui/components/Buttons';
 import { DateRangePickerConstraint } from './DatePicker/types';
 import { DashboardContext } from '../context';
+import { Span as _Span } from '../../../lib/ui/components/Typography';
 
 
 /**
@@ -31,6 +32,10 @@ type UtilityBarProps = {
  */
 const MainRow = styled(Row)`
   margin-bottom: 2rem;
+`;
+
+const Span = styled(_Span)`
+  margin-right: 1rem;
 `;
 
 /**
@@ -96,8 +101,10 @@ const UtilityBar: React.FunctionComponent<UtilityBarProps> = (props) => {
         />
       </Col>
       <Col xs={6}>
-        <Row end="xs">
+        <Row end="xs" middle="xs">
+          <Span>Group by:</Span>
           {customToggle}
+          <Span role="img" aria-label="sheep">ⓘ</Span>
           <UnitToggle onChange={onDisplayUnitChange} />
           <DownloadButton onClick={onDownloadClick}>Download</DownloadButton>
         </Row>

--- a/dashboard-app/src/features/dashboard/context.ts
+++ b/dashboard-app/src/features/dashboard/context.ts
@@ -1,0 +1,12 @@
+import { createContext, SetStateAction, Dispatch } from 'react';
+import { DurationUnitEnum } from '../../types';
+
+type DashboardContext = {
+  unit: DurationUnitEnum;
+  setUnit: Dispatch<SetStateAction<DurationUnitEnum>>;
+};
+
+export const DashboardContext = createContext<DashboardContext>({
+  unit: DurationUnitEnum.HOURS,
+  setUnit: () => {},
+});

--- a/dashboard-app/src/features/dashboard/copy/titles.ts
+++ b/dashboard-app/src/features/dashboard/copy/titles.ts
@@ -13,6 +13,6 @@ export const TitlesCopy = {
   },
   Projects: {
     title: 'Projects',
-    subtitle: 'See what projects volunteers spend their time doing',
+    subtitle: 'See what projects & activities volunteers spend their time doing',
   },
 };

--- a/dashboard-app/src/features/dashboard/copy/titles.ts
+++ b/dashboard-app/src/features/dashboard/copy/titles.ts
@@ -13,6 +13,6 @@ export const TitlesCopy = {
   },
   Projects: {
     title: 'Projects',
-    subtitle: 'See what projects & activities volunteers spend their time doing',
+    subtitle: 'See what projects volunteers spend their time doing',
   },
 };

--- a/dashboard-app/src/features/dashboard/dataManipulation/logsToAggregatedData.ts
+++ b/dashboard-app/src/features/dashboard/dataManipulation/logsToAggregatedData.ts
@@ -67,12 +67,11 @@ export const logsToAggregatedData = ({ logs, tableType, xData, yData }: Params):
   // Interpolate null values in both dimensions (X-data and Y-data)
   // (necessary when values exist in X- and Y-data that aren't present in the logs)
   // { [X]: { [Y]: Duration } } -> { [X]: { [Y]: Duration } }
-  const z = interpolateObjFrom(xData.map((x) => x.name), Duration.fromSeconds(0), y);
-  const q = mapValues((zs) => interpolateObjFrom(yData.map((y) => y.name), Duration.fromSeconds(0), zs), z)
+  const z = mapValues((ys) => interpolateObjFrom(yData.map((y) => y.name), Duration.fromSeconds(0), ys), y);
 
   // Transform into row
   // { [X]: { [Y]: Duration } } -> ({ [Y]: Duration } & { name: [X], id: number })[]
-  const rows = Object.entries(q)
+  const rows = Object.entries(z)
     .reduce((acc, [X, Ys]) =>
       acc.concat(Object.assign({}, Ys, getIdAndName(tableType.xIdFromLogs, xData, X))), [] as Row[]);
 

--- a/dashboard-app/src/features/dashboard/dataManipulation/logsToAggregatedData.ts
+++ b/dashboard-app/src/features/dashboard/dataManipulation/logsToAggregatedData.ts
@@ -1,5 +1,5 @@
 import { Duration } from 'twine-util';
-import { collectBy } from 'twine-util/arrays';
+import { collectBy, interpolateObjFrom } from 'twine-util/arrays';
 import { mapValues } from 'twine-util/objects';
 import { Dictionary } from 'ramda';
 import { TableTypeItem } from './tableType';
@@ -64,19 +64,15 @@ export const logsToAggregatedData = ({ logs, tableType, xData, yData }: Params):
   // { [X]: { [Y]: Log[] } } -> { [X]: { [Y]: Duration } }
   const y = mapValues((ys) => mapValues((_logs) => Duration.accumulate(_logs.map((l) => l.duration)), ys), x);
 
-  // Interpolate Y-data (necessary when Y-data is month based)
+  // Interpolate null values in both dimensions (X-data and Y-data)
+  // (necessary when values exist in X- and Y-data that aren't present in the logs)
   // { [X]: { [Y]: Duration } } -> { [X]: { [Y]: Duration } }
-  const z = mapValues((ys) =>
-    yData.reduce((acc, yDataPt) =>
-      ys.hasOwnProperty(yDataPt.name)
-        ? acc
-        : { ...acc, [yDataPt.name]: Duration.fromSeconds(0) },
-      ys),
-    y);
+  const z = interpolateObjFrom(xData.map((x) => x.name), Duration.fromSeconds(0), y);
+  const q = mapValues((zs) => interpolateObjFrom(yData.map((y) => y.name), Duration.fromSeconds(0), zs), z)
 
   // Transform into row
   // { [X]: { [Y]: Duration } } -> ({ [Y]: Duration } & { name: [X], id: number })[]
-  const rows = Object.entries(z)
+  const rows = Object.entries(q)
     .reduce((acc, [X, Ys]) =>
       acc.concat(Object.assign({}, Ys, getIdAndName(tableType.xIdFromLogs, xData, X))), [] as Row[]);
 

--- a/dashboard-app/src/features/dashboard/dataManipulation/tableType.ts
+++ b/dashboard-app/src/features/dashboard/dataManipulation/tableType.ts
@@ -12,6 +12,7 @@ interface TableType {
   MonthByActivity: TableTypeItem;
   MonthByName: TableTypeItem;
   ActivityByProject: TableTypeItem;
+  ProjectByActivity: TableTypeItem;
 }
 
 // TODO : get log type from api
@@ -45,5 +46,11 @@ export const tableType: TableType = {
     groupByY: 'Activity',
     xIdFromLogs: 'project',
     getYIdFromLogs: (x: any) => x.activity,
-  }
+  },
+  ProjectByActivity: {
+    groupByX: 'Activity',
+    groupByY: 'Project',
+    xIdFromLogs: 'activity',
+    getYIdFromLogs: (x: any) => x.project,
+  },
 };

--- a/dashboard-app/src/lib/ui/components/Buttons.tsx
+++ b/dashboard-app/src/lib/ui/components/Buttons.tsx
@@ -54,7 +54,7 @@ export const RoundedButton = styled(PrimaryButton)`
 
 export const DownloadButton = styled(Button)`
   font-size: ${Fonts.size.body};
-  padding: 0em 1em;
+  padding: 0.7rem 1rem;
   margin: 0 1rem;
   background-color: ${ColoursEnum.darkGrey};
   transition: background-color ease 0.3s;

--- a/lib/twine-util/arrays.ts
+++ b/lib/twine-util/arrays.ts
@@ -57,3 +57,6 @@ export const truncate = <T>(xs: T[], limit: number, placeholder: T) =>
     : xs;
 
 export const headOrId = <T>(xs: T | T[]) => Array.isArray(xs) ? xs[0] : xs;
+
+export const interpolateObjFrom = <T, U extends object> (xs: string[], zero: T, obj: U) =>
+  xs.reduce((acc, x) => x in acc ? acc : { ...acc, [x]: zero }, obj);

--- a/lib/twine-util/package.json
+++ b/lib/twine-util/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "jest",
     "cover": "jest --coverage",
-    "build": "tsc",
+    "build": "tsc --build tsconfig.production.json",
     "lint": "eslint *.ts",
     "postinstall": "npm run build"
   },

--- a/lib/twine-util/tsconfig.json
+++ b/lib/twine-util/tsconfig.json
@@ -7,7 +7,9 @@
     "removeComments": false,
     "preserveConstEnums": true,
     "sourceMap": true,
-    "lib": ["es2017"],
+    "lib": [
+      "es2017"
+    ],
     "declaration": true,
   }
 }

--- a/lib/twine-util/tsconfig.production.json
+++ b/lib/twine-util/tsconfig.production.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "__tests__"
+  ]
+}


### PR DESCRIPTION
Changes made as part of adding projects chart (see #335)

### Changes
- Add `ProjectsActivitiesToggle` component
- Add ability to prepend additional toggle to `UtilityBar` component
- Switch between two `TableTypeItem` values depending on value of toggle
- Return `yData` directly from `useAggregateDataByProject`

### Testing Requirements
- [x] Dashboard
  - As many combinations of switching back and forth between projects/activities, tables/charts as you can manage

### Release Requirements
- Merge to feature-branch, PO to review feature branch, then release.

### Manual Deployment
- N/A
