### PR TITLE
♻️ modify visit-logs api to allow time filtering

### DIFF
--- a/api/src/api/v1/community_businesses/visit_logs_aggregates.ts
+++ b/api/src/api/v1/community_businesses/visit_logs_aggregates.ts
@@ -1,4 +1,3 @@
-import * as Hapi from '@hapi/hapi';
 import * as Boom from '@hapi/boom';
 import { omit, filter, complement, isEmpty } from 'ramda';
 import { query, response } from './schema';

--- a/api/src/api/v1/community_businesses/volunteer_logs.ts
+++ b/api/src/api/v1/community_businesses/volunteer_logs.ts
@@ -119,7 +119,7 @@ const routes: [
           scope: ['volunteer_logs-sibling:read', 'volunteer_logs-child:read'],
         },
       },
-      validate: { query: { since, until } },
+      validate: { params: { logId: id } },
       response: { schema: response },
       pre: [
         { method: getCommunityBusiness, assign: 'communityBusiness' },

--- a/api/src/api/v1/schema/request.ts
+++ b/api/src/api/v1/schema/request.ts
@@ -93,7 +93,7 @@ export const id =
   Joi.number().integer().positive();
 
 export const since = Joi.date().iso().default('1970-01-01T00:00:00.000Z');
-export const until = Joi.date().iso().default(() => Date.now(), 'Current date');
+export const until = Joi.date().iso().default(() => new Date().toISOString(), 'Current date');
 
 export const startedAt =
   DateJoi.dynamicdate()

--- a/api/src/api/v1/types/api.ts
+++ b/api/src/api/v1/types/api.ts
@@ -144,6 +144,8 @@ export namespace Api {
           export interface Request extends Hapi.Request {
             pre: { communityBusiness: CommunityBusiness };
             query: ApiRequestQuery & Dictionary<any> & {
+              since?: string;
+              until?: string;
               filter?: {
                 age?: [number, number];
                 gender?: GenderEnum;

--- a/api/src/api/v1/user_logs/visit_logs.ts
+++ b/api/src/api/v1/user_logs/visit_logs.ts
@@ -1,7 +1,6 @@
-import * as Boom from '@hapi/boom';
 import { since, until } from '../schema/request';
 import { response } from '../schema/response';
-import { isChildOrganisation, requireChildOrganisation } from '../prerequisites';
+import { requireChildOrganisation } from '../prerequisites';
 import { Api } from '../types/api';
 
 

--- a/api/src/api/v1/user_logs/volunteer_logs.ts
+++ b/api/src/api/v1/user_logs/volunteer_logs.ts
@@ -1,4 +1,3 @@
-import * as Boom from '@hapi/boom';
 import { since, until } from '../schema/request';
 import { response } from '../schema/response';
 import { requireChildOrganisation } from '../prerequisites';

--- a/api/src/api/v1/users/schema.ts
+++ b/api/src/api/v1/users/schema.ts
@@ -16,7 +16,7 @@ export const userName =
   Joi.string()
     .min(3)
     .max(100)
-    .regex(/^[a-zA-Z]{2,}\s?[a-zA-z]*['\-]?[a-zA-Z]*['\- ]?([a-zA-Z]{1,})?/, { name: 'alpha' })
+    .regex(/^[a-zA-Z]{2,}\s?[a-zA-z]*['-]?[a-zA-Z]*['\- ]?([a-zA-Z]{1,})?/, { name: 'alpha' })
     .trim()
     .options({ language: { string: { regex: { name: 'can only contain letters' } } } });
 

--- a/api/src/models/__tests__/visitor.test.integration.ts
+++ b/api/src/models/__tests__/visitor.test.integration.ts
@@ -96,7 +96,7 @@ describe('Visitor model', () => {
       expect(visitors[0].visits).toHaveLength(10);
       expect(visitors[0].visits).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ visitActivity: 'Free Running' }),
+          expect.objectContaining({ visitActivity: 'Free Running', category: 'Sports' }),
         ])
       );
     });
@@ -121,7 +121,7 @@ describe('Visitor model', () => {
       expect(visitors[0].visits).toHaveLength(10);
       expect(visitors[0].visits).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ visitActivity: 'Free Running' }),
+          expect.objectContaining({ visitActivity: 'Free Running', category: 'Sports' }),
         ])
       );
       expect(visitors[3]).toEqual({ ...visitor, visits: [] });

--- a/api/src/models/community_business.ts
+++ b/api/src/models/community_business.ts
@@ -503,7 +503,7 @@ export const CommunityBusinesses: CommunityBusinessCollection = {
       }),
       whereBetween: pipe(
         evolve({ birthYear: AgeList.toBirthYear }),
-        Objects.renameKeys({ birthYear: 'user_account.birth_year' })
+        Objects.renameKeys({ birthYear: 'user_account.birth_year', createdAt: 'visit_log.created_at' })
       ),
     });
     const checkSpecificCb = assocPath(['where', 'visit_activity.organisation_id'], cb.id);

--- a/api/src/models/types.ts
+++ b/api/src/models/types.ts
@@ -218,6 +218,7 @@ export type VisitEvent = Readonly<CommonTimestamps & {
 
 export type LinkedVisitEvent = VisitEvent & Readonly<{
   visitActivity: string
+  category: string
 }>;
 
 export type Feedback = Readonly<CommonTimestamps & {

--- a/api/src/models/visitor.ts
+++ b/api/src/models/visitor.ts
@@ -143,6 +143,7 @@ export const Visitors: VisitorCollection = {
       userId: 'visit_log.user_account_id',
       visitActivityId: 'visit_activity.visit_activity_id',
       visitActivity: 'visit_activity.visit_activity_name',
+      category: 'visit_activity_category.visit_activity_category_name',
     };
 
     const rows: Partial<User>[] = await applyQueryModifiers(
@@ -178,6 +179,10 @@ export const Visitors: VisitorCollection = {
           'visit_activity',
           'visit_activity.visit_activity_id',
           'visit_log.visit_activity_id')
+        .leftOuterJoin(
+          'visit_activity_category',
+          'visit_activity_category.visit_activity_category_id',
+          'visit_activity.visit_activity_category_id')
         .where(filter(Boolean, {
           user_account_id: user.id,
           'visit_activity.visit_activity_name': activity,


### PR DESCRIPTION
related to #324 

### Changes
- Allow `since` and `until` query params on `GET /community-businesses/me/visit-logs`
- Update models: Visit events now include their category

### Testing Requirements
Manual testing done on later PRs with client-side changes

### Release Requirements
N/A - wait for later PRs

### Manual Deployment
API