### PR TITLE
✨ data processing and utilities for visits charts

### DIFF
--- a/visitor-app/src/cb_admin/pages/VisitsData/__tests__/data.test.js
+++ b/visitor-app/src/cb_admin/pages/VisitsData/__tests__/data.test.js
@@ -1,0 +1,114 @@
+import MockAdapter from 'axios-mock-adapter';
+import { axios } from '../../../../api';
+import { DateRangesEnum } from '../dateRange';
+import { getVisitorData } from '../data';
+
+
+describe('Visits Dashboard Data Processing', () => {
+  const mock = new MockAdapter(axios);
+
+  afterAll(() => mock.restore());
+
+  describe('getVisitorData', () => {
+    test(`Time: ${DateRangesEnum.LAST_12_MONTHS}, Age: All, Gender: All, Activity: All`, async () => {
+      mock.onGet('/community-businesses/me/visitors')
+        .reply(200, {
+          result: [
+            {
+              id: 1,
+              name: 'Jom',
+              gender: 'male',
+              birthYear: 1989,
+              visits: [
+                { id: 1, visitActivity: 'yoga', category: 'sport', createdAt: '2019-10-19T11:00:00.000Z' },
+                { id: 2, visitActivity: 'running', category: 'sport', createdAt: '2019-10-29T11:00:00.000Z' },
+              ],
+            },
+            {
+              id: 2,
+              name: 'Bom',
+              gender: 'female',
+              birthYear: 1955,
+              visits: [
+                { id: 3, visitActivity: 'painting', category: 'art', createdAt: '2019-10-09T11:00:00.000Z' },
+                { id: 4, visitActivity: 'running', category: 'sport', createdAt: '2019-10-21T11:00:00.000Z' },
+              ],
+            },
+          ],
+          meta: { count: 1 },
+        });
+
+      mock.onGet('/community-businesses/me/visit-activities')
+        .reply(200, {
+          result: [
+            {
+              id: 1,
+              name: 'yoga',
+              category: 'sport',
+            },
+            {
+              id: 2,
+              name: 'running',
+              category: 'sport',
+            },
+            {
+              id: 3,
+              name: 'painting',
+              category: 'art',
+            },
+          ],
+        });
+
+      const res = await getVisitorData({ time: DateRangesEnum.LAST_12_MONTHS });
+
+      expect(res).toEqual({
+        charts: {
+          category: { stepSize: 1 },
+          time: { stepSize: 1 },
+        },
+        data: {
+          age: {
+            datasets: [{ data: [1, 1], backgroundColor: ['#FDBD2D', '#833FF7', '#DBDBDB'], label: undefined }],
+            labels: ['18-34', '51-69'],
+          },
+          activity: {
+            sport: {
+              datasets: [{ data: [1, 2], backgroundColor: '#833FF7', label: undefined }],
+              labels: ['yoga', 'running'],
+            },
+            art: {
+              datasets: [{ data: [1], backgroundColor: '#833FF7', label: undefined }],
+              labels: ['painting'],
+            },
+          },
+          gender: {
+            datasets: [{ data: [1, 1], backgroundColor: ['#FDBD2D', '#833FF7', '#DBDBDB'], label: undefined }],
+            labels: ['male', 'female'],
+          },
+          time: {
+            datasets: [{ data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2], backgroundColor: '#833FF7', label: undefined }],
+            labels: [
+              'Oct 2018',
+              'Nov 2018',
+              'Dec 2018',
+              'Jan 2019',
+              'Feb 2019',
+              'Mar 2019',
+              'Apr 2019',
+              'May 2019',
+              'Jun 2019',
+              'Jul 2019',
+              'Aug 2019',
+              'Sep 2019',
+              'Oct 2019',
+            ],
+          },
+          category: {
+            datasets: [{ data: [2, 1], backgroundColor: '#833FF7', label: undefined }],
+            labels: ['sport', 'art'],
+          },
+        },
+      });
+    });
+  });
+});

--- a/visitor-app/src/cb_admin/pages/VisitsData/__tests__/data.test.js
+++ b/visitor-app/src/cb_admin/pages/VisitsData/__tests__/data.test.js
@@ -1,4 +1,5 @@
 import MockAdapter from 'axios-mock-adapter';
+import MockDate from 'mockdate';
 import { axios } from '../../../../api';
 import { DateRangesEnum } from '../dateRange';
 import { getVisitorData } from '../data';
@@ -7,10 +8,15 @@ import { getVisitorData } from '../data';
 describe('Visits Dashboard Data Processing', () => {
   const mock = new MockAdapter(axios);
 
-  afterAll(() => mock.restore());
+  afterAll(() => {
+    MockDate.reset();
+    mock.restore();
+  });
 
   describe('getVisitorData', () => {
     test(`Time: ${DateRangesEnum.LAST_12_MONTHS}, Age: All, Gender: All, Activity: All`, async () => {
+      MockDate.set('2019-10-31T23:59:59.999Z');
+
       mock.onGet('/community-businesses/me/visitors')
         .reply(200, {
           result: [

--- a/visitor-app/src/cb_admin/pages/VisitsData/__tests__/util.test.js
+++ b/visitor-app/src/cb_admin/pages/VisitsData/__tests__/util.test.js
@@ -1,5 +1,5 @@
 import Mockdate from 'mockdate';
-import { AgeGroups, Stats, calculateStepSize } from '../util';
+import { AgeGroups, VisitsStats, calculateStepSize } from '../util';
 import { DateRangesEnum } from '../dateRange';
 
 
@@ -49,10 +49,10 @@ describe('Visits Data Utilities', () => {
     });
   });
 
-  describe('Stats', () => {
+  describe('VisitsStats', () => {
     describe('calculateGenderStatistics', () => {
       test('empty list gives empty stats object', () => {
-        expect(Stats.calculateGenderStatistics([])).toEqual({});
+        expect(VisitsStats.calculateGenderStatistics([])).toEqual({});
       });
 
       test('basic sanity check', () => {
@@ -65,7 +65,7 @@ describe('Visits Data Utilities', () => {
           { gender: 'female' },
         ];
 
-        expect(Stats.calculateGenderStatistics(logs)).toEqual({
+        expect(VisitsStats.calculateGenderStatistics(logs)).toEqual({
           male: 2,
           female: 3,
           'prefer not to say': 1,
@@ -75,7 +75,7 @@ describe('Visits Data Utilities', () => {
 
     describe('calculateAgeGroupStatistics', () => {
       test('empty list gives empty stats object', () => {
-        expect(Stats.calculateAgeGroupStatistics([])).toEqual({});
+        expect(VisitsStats.calculateAgeGroupStatistics([])).toEqual({});
       });
 
       test('basic sanity check', () => {
@@ -88,7 +88,7 @@ describe('Visits Data Utilities', () => {
           { birthYear: 1988 },
         ];
 
-        expect(Stats.calculateAgeGroupStatistics(logs)).toEqual({
+        expect(VisitsStats.calculateAgeGroupStatistics(logs)).toEqual({
           '0-17': 1,
           '18-34': 2,
           '35-50': 2,
@@ -99,7 +99,7 @@ describe('Visits Data Utilities', () => {
 
     describe('calculateCategoryStatistics', () => {
       test('empty list gives empty stats object', () => {
-        expect(Stats.calculateCategoryStatistics([])).toEqual({});
+        expect(VisitsStats.calculateCategoryStatistics([])).toEqual({});
       });
 
       test('basic sanity check', () => {
@@ -112,7 +112,7 @@ describe('Visits Data Utilities', () => {
           { category: '---' },
         ];
 
-        expect(Stats.calculateCategoryStatistics(logs)).toEqual({
+        expect(VisitsStats.calculateCategoryStatistics(logs)).toEqual({
           foo: 3,
           bar: 2,
           '---': 1,
@@ -122,7 +122,7 @@ describe('Visits Data Utilities', () => {
 
     describe('calculateActivityStatistics', () => {
       test('empty list gives empty stats object', () => {
-        expect(Stats.calculateActivityStatistics([])).toEqual({});
+        expect(VisitsStats.calculateActivityStatistics([])).toEqual({});
       });
 
       test('basic sanity check', () => {
@@ -135,7 +135,7 @@ describe('Visits Data Utilities', () => {
           { category: '---', visitActivity: 'five' },
         ];
 
-        expect(Stats.calculateActivityStatistics(logs)).toEqual({
+        expect(VisitsStats.calculateActivityStatistics(logs)).toEqual({
           foo: { one: 2, four: 1 },
           bar: { two: 1, three: 1 },
           '---': { five: 1 },
@@ -149,7 +149,7 @@ describe('Visits Data Utilities', () => {
         const until = new Date('2019-10-31');
         const dateRange = DateRangesEnum.LAST_12_MONTHS;
 
-        expect(Stats.calculateTimePeriodStatistics(since, until, dateRange, [])).toEqual({
+        expect(VisitsStats.calculateTimePeriodStatistics(since, until, dateRange, [])).toEqual({
           'Dec 2018': 0,
           'Jan 2019': 0,
           'Feb 2019': 0,
@@ -164,7 +164,7 @@ describe('Visits Data Utilities', () => {
         });
       });
 
-      test('basic sanity check', () => {
+      test(`basic sanity check :: ${DateRangesEnum.LAST_12_MONTHS}`, () => {
         const since = new Date('2018-12-01');
         const until = new Date('2019-10-31');
         const dateRange = DateRangesEnum.LAST_12_MONTHS;
@@ -178,7 +178,7 @@ describe('Visits Data Utilities', () => {
           { createdAt: '2019-01-02' },
         ];
 
-        expect(Stats.calculateTimePeriodStatistics(since, until, dateRange, logs)).toEqual({
+        expect(VisitsStats.calculateTimePeriodStatistics(since, until, dateRange, logs)).toEqual({
           'Dec 2018': 1,
           'Jan 2019': 1,
           'Feb 2019': 0,
@@ -190,6 +190,50 @@ describe('Visits Data Utilities', () => {
           'Aug 2019': 1,
           'Sep 2019': 0,
           'Oct 2019': 2,
+        });
+      });
+
+      test(`basic sanity check :: ${DateRangesEnum.LAST_MONTH}`, () => {
+        const since = new Date('2019-10-01');
+        const until = new Date('2019-10-31');
+        const dateRange = DateRangesEnum.LAST_MONTH;
+
+        const logs = [
+          { createdAt: '2019-10-10' },
+          { createdAt: '2019-10-15' },
+          { createdAt: '2019-10-22' },
+          { createdAt: '2019-10-12' },
+        ];
+
+        expect(VisitsStats.calculateTimePeriodStatistics(since, until, dateRange, logs)).toEqual({
+          '30 Sep': 0,
+          '07 Oct': 2,
+          '14 Oct': 1,
+          '21 Oct': 1,
+          '28 Oct': 0,
+        });
+      });
+
+      test(`basic sanity check :: ${DateRangesEnum.LAST_WEEK}`, () => {
+        const since = new Date('2019-10-24');
+        const until = new Date('2019-10-31');
+        const dateRange = DateRangesEnum.LAST_WEEK;
+
+        const logs = [
+          { createdAt: '2019-10-24' },
+          { createdAt: '2019-10-25' },
+          { createdAt: '2019-10-28' },
+          { createdAt: '2019-10-30' },
+        ];
+
+        expect(VisitsStats.calculateTimePeriodStatistics(since, until, dateRange, logs)).toEqual({
+          '24 Oct': 1,
+          '25 Oct': 1,
+          '26 Oct': 0,
+          '27 Oct': 0,
+          '28 Oct': 1,
+          '29 Oct': 0,
+          '30 Oct': 1,
         });
       });
     });

--- a/visitor-app/src/cb_admin/pages/VisitsData/__tests__/util.test.js
+++ b/visitor-app/src/cb_admin/pages/VisitsData/__tests__/util.test.js
@@ -1,0 +1,210 @@
+import Mockdate from 'mockdate';
+import { AgeGroups, Stats, calculateStepSize } from '../util';
+import { DateRangesEnum } from '../dateRange';
+
+
+describe('Visits Data Utilities', () => {
+  describe('AgeGroups', () => {
+    test(':: toSelectOptions', () => {
+      expect(AgeGroups.toSelectOptions()).toEqual([
+        { key: 0, value: 'All' },
+        { key: 1, value: '0-17' },
+        { key: 2, value: '18-34' },
+        { key: 3, value: '35-50' },
+        { key: 4, value: '51-69' },
+        { key: 5, value: '70+' },
+      ]);
+    });
+
+    describe(':: fromBirthYear', () => {
+      beforeAll(() => {
+        Mockdate.set('2019-10-01');
+      });
+
+      afterAll(() => {
+        Mockdate.reset();
+      });
+
+      Object.entries({
+        invalid: [2100, 2040],
+        '0-17': [2019, 2009, 2007, 2015, 2003, 2002],
+        '18-34': [2001, 1999, 1990, 1989, 1985],
+        '35-50': [1984, 1980, 1979, 1971, 1969],
+        '51-69': [1968, 1962, 1960, 1955, 1951, 1950],
+        '70+': [1943, 1936, 1918, 1917, 1912],
+      })
+        .forEach(([group, years]) => {
+          const label = group === 'invalid' ? 'are' : 'should be in';
+
+          years.forEach((year) => {
+            test(`${year} ${label} ${group}`, () => {
+              if (group === 'invalid') {
+                expect(() => AgeGroups.fromBirthYear(year)).toThrow();
+              } else {
+                expect(AgeGroups.fromBirthYear(year)).toBe(group);
+              }
+            });
+          });
+        });
+    });
+  });
+
+  describe('Stats', () => {
+    describe('calculateGenderStatistics', () => {
+      test('empty list gives empty stats object', () => {
+        expect(Stats.calculateGenderStatistics([])).toEqual({});
+      });
+
+      test('basic sanity check', () => {
+        const logs = [
+          { gender: 'male' },
+          { gender: 'female' },
+          { gender: 'prefer not to say' },
+          { gender: 'male' },
+          { gender: 'female' },
+          { gender: 'female' },
+        ];
+
+        expect(Stats.calculateGenderStatistics(logs)).toEqual({
+          male: 2,
+          female: 3,
+          'prefer not to say': 1,
+        });
+      });
+    });
+
+    describe('calculateAgeGroupStatistics', () => {
+      test('empty list gives empty stats object', () => {
+        expect(Stats.calculateAgeGroupStatistics([])).toEqual({});
+      });
+
+      test('basic sanity check', () => {
+        const logs = [
+          { birthYear: 1999 },
+          { birthYear: 2019 },
+          { birthYear: 1980 },
+          { birthYear: 1954 },
+          { birthYear: 1971 },
+          { birthYear: 1988 },
+        ];
+
+        expect(Stats.calculateAgeGroupStatistics(logs)).toEqual({
+          '0-17': 1,
+          '18-34': 2,
+          '35-50': 2,
+          '51-69': 1,
+        });
+      });
+    });
+
+    describe('calculateCategoryStatistics', () => {
+      test('empty list gives empty stats object', () => {
+        expect(Stats.calculateCategoryStatistics([])).toEqual({});
+      });
+
+      test('basic sanity check', () => {
+        const logs = [
+          { category: 'foo' },
+          { category: 'foo' },
+          { category: 'bar' },
+          { category: 'bar' },
+          { category: 'foo' },
+          { category: '---' },
+        ];
+
+        expect(Stats.calculateCategoryStatistics(logs)).toEqual({
+          foo: 3,
+          bar: 2,
+          '---': 1,
+        });
+      });
+    });
+
+    describe('calculateActivityStatistics', () => {
+      test('empty list gives empty stats object', () => {
+        expect(Stats.calculateActivityStatistics([])).toEqual({});
+      });
+
+      test('basic sanity check', () => {
+        const logs = [
+          { category: 'foo', visitActivity: 'one' },
+          { category: 'foo', visitActivity: 'one' },
+          { category: 'bar', visitActivity: 'two' },
+          { category: 'bar', visitActivity: 'three' },
+          { category: 'foo', visitActivity: 'four' },
+          { category: '---', visitActivity: 'five' },
+        ];
+
+        expect(Stats.calculateActivityStatistics(logs)).toEqual({
+          foo: { one: 2, four: 1 },
+          bar: { two: 1, three: 1 },
+          '---': { five: 1 },
+        });
+      });
+    });
+
+    describe('calculateTimePeriodStatistics', () => {
+      test('empty list gives empty stats object', () => {
+        const since = new Date('2018-12-01');
+        const until = new Date('2019-10-31');
+        const dateRange = DateRangesEnum.LAST_12_MONTHS;
+
+        expect(Stats.calculateTimePeriodStatistics(since, until, dateRange, [])).toEqual({
+          'Dec 2018': 0,
+          'Jan 2019': 0,
+          'Feb 2019': 0,
+          'Mar 2019': 0,
+          'Apr 2019': 0,
+          'May 2019': 0,
+          'Jun 2019': 0,
+          'Jul 2019': 0,
+          'Aug 2019': 0,
+          'Sep 2019': 0,
+          'Oct 2019': 0,
+        });
+      });
+
+      test('basic sanity check', () => {
+        const since = new Date('2018-12-01');
+        const until = new Date('2019-10-31');
+        const dateRange = DateRangesEnum.LAST_12_MONTHS;
+
+        const logs = [
+          { createdAt: '2019-10-10' },
+          { createdAt: '2019-10-15' },
+          { createdAt: '2019-06-12' },
+          { createdAt: '2019-08-22' },
+          { createdAt: '2018-12-12' },
+          { createdAt: '2019-01-02' },
+        ];
+
+        expect(Stats.calculateTimePeriodStatistics(since, until, dateRange, logs)).toEqual({
+          'Dec 2018': 1,
+          'Jan 2019': 1,
+          'Feb 2019': 0,
+          'Mar 2019': 0,
+          'Apr 2019': 0,
+          'May 2019': 0,
+          'Jun 2019': 1,
+          'Jul 2019': 0,
+          'Aug 2019': 1,
+          'Sep 2019': 0,
+          'Oct 2019': 2,
+        });
+      });
+    });
+  });
+
+  describe('calculateStepSize', () => {
+    test('minimum of one for empty input object', () => {
+      expect(calculateStepSize({})).toBe(1);
+    });
+
+    test('step size should give approx. five ticks', () => {
+      expect(calculateStepSize({ foo: 10 })).toBe(2);
+      expect(calculateStepSize({ foo: 10, bar: 1 })).toBe(2);
+      expect(calculateStepSize({ foo: 10, bar: 100 })).toBe(20);
+      expect(calculateStepSize({ foo: 22, bar: 12 })).toBe(4);
+    });
+  });
+});

--- a/visitor-app/src/cb_admin/pages/VisitsData/__tests__/util.test.js
+++ b/visitor-app/src/cb_admin/pages/VisitsData/__tests__/util.test.js
@@ -1,5 +1,5 @@
 import Mockdate from 'mockdate';
-import { AgeGroups, VisitsStats, calculateStepSize } from '../util';
+import { AgeGroups, VisitsStats, VisitorStats, calculateStepSize } from '../util';
 import { DateRangesEnum } from '../dateRange';
 
 
@@ -227,6 +227,204 @@ describe('Visits Data Utilities', () => {
         ];
 
         expect(VisitsStats.calculateTimePeriodStatistics(since, until, dateRange, logs)).toEqual({
+          '24 Oct': 1,
+          '25 Oct': 1,
+          '26 Oct': 0,
+          '27 Oct': 0,
+          '28 Oct': 1,
+          '29 Oct': 0,
+          '30 Oct': 1,
+        });
+      });
+    });
+  });
+
+  describe.only('VisitorStats', () => {
+    describe('calculateGenderStatistics', () => {
+      test('empty list gives empty stats object', () => {
+        expect(VisitorStats.calculateGenderStatistics([])).toEqual({});
+      });
+
+      test('basic sanity check', () => {
+        const visitors = [
+          { gender: 'male' },
+          { gender: 'female' },
+          { gender: 'prefer not to say' },
+          { gender: 'male' },
+          { gender: 'female' },
+          { gender: 'female' },
+        ];
+
+        expect(VisitorStats.calculateGenderStatistics(visitors)).toEqual({
+          male: 2,
+          female: 3,
+          'prefer not to say': 1,
+        });
+      });
+    });
+
+    describe('calculateAgeGroupStatistics', () => {
+      test('empty list gives empty stats object', () => {
+        expect(VisitorStats.calculateAgeGroupStatistics([])).toEqual({});
+      });
+
+      test('basic sanity check', () => {
+        const visitors = [
+          { birthYear: 1999 },
+          { birthYear: 2019 },
+          { birthYear: 1980 },
+          { birthYear: 1954 },
+          { birthYear: 1971 },
+          { birthYear: 1988 },
+        ];
+
+        expect(VisitorStats.calculateAgeGroupStatistics(visitors)).toEqual({
+          '0-17': 1,
+          '18-34': 2,
+          '35-50': 2,
+          '51-69': 1,
+        });
+      });
+    });
+
+    describe('calculateCategoryStatistics', () => {
+      test('empty list gives empty stats object', () => {
+        expect(VisitorStats.calculateCategoryStatistics([])).toEqual({});
+      });
+
+      test('basic sanity check', () => {
+        const visitors = [
+          { category: ['foo'] },
+          { category: ['foo'] },
+          { category: ['bar'] },
+          { category: ['bar'] },
+          { category: ['foo'] },
+          { category: ['---'] },
+        ];
+
+        expect(VisitorStats.calculateCategoryStatistics(visitors)).toEqual({
+          foo: 3,
+          bar: 2,
+          '---': 1,
+        });
+      });
+    });
+
+    describe('calculateActivityStatistics', () => {
+      test('empty list gives empty stats object', () => {
+        expect(VisitorStats.calculateActivityStatistics([], [])).toEqual({});
+      });
+
+      test('basic sanity check', () => {
+        const visitors = [
+          { category: ['foo'], visitActivity: ['one'] },
+          { category: ['foo'], visitActivity: ['one'] },
+          { category: ['bar'], visitActivity: ['two'] },
+          { category: ['bar'], visitActivity: ['three'] },
+          { category: ['foo'], visitActivity: ['four'] },
+          { category: ['---'], visitActivity: ['five'] },
+        ];
+
+        const activities = [
+          { name: 'one', category: 'foo' },
+          { name: 'two', category: 'bar' },
+          { name: 'three', category: 'bar' },
+          { name: 'four', category: 'foo' },
+          { name: 'five', category: '---' },
+        ]
+
+        expect(VisitorStats.calculateActivityStatistics(visitors, activities)).toEqual({
+          foo: { one: 2, four: 1 },
+          bar: { two: 1, three: 1 },
+          '---': { five: 1 },
+        });
+      });
+    });
+
+    describe('calculateTimePeriodStatistics', () => {
+      test('empty list gives empty stats object', () => {
+        const since = new Date('2018-12-01');
+        const until = new Date('2019-10-31');
+        const dateRange = DateRangesEnum.LAST_12_MONTHS;
+
+        expect(VisitorStats.calculateTimePeriodStatistics(since, until, dateRange, [])).toEqual({
+          'Dec 2018': 0,
+          'Jan 2019': 0,
+          'Feb 2019': 0,
+          'Mar 2019': 0,
+          'Apr 2019': 0,
+          'May 2019': 0,
+          'Jun 2019': 0,
+          'Jul 2019': 0,
+          'Aug 2019': 0,
+          'Sep 2019': 0,
+          'Oct 2019': 0,
+        });
+      });
+
+      test(`basic sanity check :: ${DateRangesEnum.LAST_12_MONTHS}`, () => {
+        const since = new Date('2018-12-01');
+        const until = new Date('2019-10-31');
+        const dateRange = DateRangesEnum.LAST_12_MONTHS;
+
+        const visitors = [
+          { createdAt: ['2019-10-10', '2019-10-11', '2019-06-15'] },
+          { createdAt: ['2019-10-15'] },
+          { createdAt: ['2019-06-12'] },
+          { createdAt: ['2019-08-22'] },
+          { createdAt: ['2018-12-12'] },
+          { createdAt: ['2019-01-02'] },
+        ];
+
+        expect(VisitorStats.calculateTimePeriodStatistics(since, until, dateRange, visitors)).toEqual({
+          'Dec 2018': 1,
+          'Jan 2019': 1,
+          'Feb 2019': 0,
+          'Mar 2019': 0,
+          'Apr 2019': 0,
+          'May 2019': 0,
+          'Jun 2019': 1,
+          'Jul 2019': 0,
+          'Aug 2019': 1,
+          'Sep 2019': 0,
+          'Oct 2019': 2,
+        });
+      });
+
+      test(`basic sanity check :: ${DateRangesEnum.LAST_MONTH}`, () => {
+        const since = new Date('2019-10-01');
+        const until = new Date('2019-10-31');
+        const dateRange = DateRangesEnum.LAST_MONTH;
+
+        const logs = [
+          { createdAt: '2019-10-10' },
+          { createdAt: '2019-10-15' },
+          { createdAt: '2019-10-22' },
+          { createdAt: '2019-10-12' },
+        ];
+
+        expect(VisitorStats.calculateTimePeriodStatistics(since, until, dateRange, logs)).toEqual({
+          '30 Sep': 0,
+          '07 Oct': 2,
+          '14 Oct': 1,
+          '21 Oct': 1,
+          '28 Oct': 0,
+        });
+      });
+
+      test(`basic sanity check :: ${DateRangesEnum.LAST_WEEK}`, () => {
+        const since = new Date('2019-10-24');
+        const until = new Date('2019-10-31');
+        const dateRange = DateRangesEnum.LAST_WEEK;
+
+        const logs = [
+          { createdAt: '2019-10-24' },
+          { createdAt: '2019-10-25' },
+          { createdAt: '2019-10-28' },
+          { createdAt: '2019-10-30' },
+        ];
+
+        expect(VisitorStats.calculateTimePeriodStatistics(since, until, dateRange, logs)).toEqual({
           '24 Oct': 1,
           '25 Oct': 1,
           '26 Oct': 0,

--- a/visitor-app/src/cb_admin/pages/VisitsData/__tests__/util.test.js
+++ b/visitor-app/src/cb_admin/pages/VisitsData/__tests__/util.test.js
@@ -331,7 +331,7 @@ describe('Visits Data Utilities', () => {
           { name: 'three', category: 'bar' },
           { name: 'four', category: 'foo' },
           { name: 'five', category: '---' },
-        ]
+        ];
 
         expect(VisitorStats.calculateActivityStatistics(visitors, activities)).toEqual({
           foo: { one: 2, four: 1 },
@@ -376,19 +376,20 @@ describe('Visits Data Utilities', () => {
           { createdAt: ['2019-01-02'] },
         ];
 
-        expect(VisitorStats.calculateTimePeriodStatistics(since, until, dateRange, visitors)).toEqual({
-          'Dec 2018': 1,
-          'Jan 2019': 1,
-          'Feb 2019': 0,
-          'Mar 2019': 0,
-          'Apr 2019': 0,
-          'May 2019': 0,
-          'Jun 2019': 1,
-          'Jul 2019': 0,
-          'Aug 2019': 1,
-          'Sep 2019': 0,
-          'Oct 2019': 2,
-        });
+        expect(VisitorStats.calculateTimePeriodStatistics(since, until, dateRange, visitors))
+          .toEqual({
+            'Dec 2018': 1,
+            'Jan 2019': 1,
+            'Feb 2019': 0,
+            'Mar 2019': 0,
+            'Apr 2019': 0,
+            'May 2019': 0,
+            'Jun 2019': 1,
+            'Jul 2019': 0,
+            'Aug 2019': 1,
+            'Sep 2019': 0,
+            'Oct 2019': 2,
+          });
       });
 
       test(`basic sanity check :: ${DateRangesEnum.LAST_MONTH}`, () => {

--- a/visitor-app/src/cb_admin/pages/VisitsData/__tests__/util.test.js
+++ b/visitor-app/src/cb_admin/pages/VisitsData/__tests__/util.test.js
@@ -215,8 +215,8 @@ describe('Visits Data Utilities', () => {
       });
 
       test(`basic sanity check :: ${DateRangesEnum.LAST_WEEK}`, () => {
-        const since = new Date('2019-10-24');
-        const until = new Date('2019-10-31');
+        const since = '2019-10-24';
+        const until = '2019-10-31';
         const dateRange = DateRangesEnum.LAST_WEEK;
 
         const logs = [
@@ -234,6 +234,7 @@ describe('Visits Data Utilities', () => {
           '28 Oct': 1,
           '29 Oct': 0,
           '30 Oct': 1,
+          '31 Oct': 0,
         });
       });
     });
@@ -415,8 +416,8 @@ describe('Visits Data Utilities', () => {
       });
 
       test(`basic sanity check :: ${DateRangesEnum.LAST_WEEK}`, () => {
-        const since = new Date('2019-10-24');
-        const until = new Date('2019-10-31');
+        const since = '2019-10-24';
+        const until = '2019-10-31';
         const dateRange = DateRangesEnum.LAST_WEEK;
 
         const visitors = [
@@ -435,6 +436,7 @@ describe('Visits Data Utilities', () => {
             '28 Oct': 1,
             '29 Oct': 0,
             '30 Oct': 1,
+            '31 Oct': 0,
           });
       });
     });

--- a/visitor-app/src/cb_admin/pages/VisitsData/__tests__/util.test.js
+++ b/visitor-app/src/cb_admin/pages/VisitsData/__tests__/util.test.js
@@ -384,7 +384,7 @@ describe('Visits Data Utilities', () => {
             'Mar 2019': 0,
             'Apr 2019': 0,
             'May 2019': 0,
-            'Jun 2019': 1,
+            'Jun 2019': 2,
             'Jul 2019': 0,
             'Aug 2019': 1,
             'Sep 2019': 0,
@@ -397,20 +397,21 @@ describe('Visits Data Utilities', () => {
         const until = new Date('2019-10-31');
         const dateRange = DateRangesEnum.LAST_MONTH;
 
-        const logs = [
-          { createdAt: '2019-10-10' },
-          { createdAt: '2019-10-15' },
-          { createdAt: '2019-10-22' },
-          { createdAt: '2019-10-12' },
+        const visitors = [
+          { createdAt: ['2019-10-10'] },
+          { createdAt: ['2019-10-15', '2019-10-02'] },
+          { createdAt: ['2019-10-22'] },
+          { createdAt: ['2019-10-12', '2019-10-05'] },
         ];
 
-        expect(VisitorStats.calculateTimePeriodStatistics(since, until, dateRange, logs)).toEqual({
-          '30 Sep': 0,
-          '07 Oct': 2,
-          '14 Oct': 1,
-          '21 Oct': 1,
-          '28 Oct': 0,
-        });
+        expect(VisitorStats.calculateTimePeriodStatistics(since, until, dateRange, visitors))
+          .toEqual({
+            '30 Sep': 2,
+            '07 Oct': 2,
+            '14 Oct': 1,
+            '21 Oct': 1,
+            '28 Oct': 0,
+          });
       });
 
       test(`basic sanity check :: ${DateRangesEnum.LAST_WEEK}`, () => {
@@ -418,22 +419,23 @@ describe('Visits Data Utilities', () => {
         const until = new Date('2019-10-31');
         const dateRange = DateRangesEnum.LAST_WEEK;
 
-        const logs = [
-          { createdAt: '2019-10-24' },
-          { createdAt: '2019-10-25' },
-          { createdAt: '2019-10-28' },
-          { createdAt: '2019-10-30' },
+        const visitors = [
+          { createdAt: ['2019-10-24'] },
+          { createdAt: ['2019-10-25'] },
+          { createdAt: ['2019-10-28'] },
+          { createdAt: ['2019-10-30', '2019-10-30'] },
         ];
 
-        expect(VisitorStats.calculateTimePeriodStatistics(since, until, dateRange, logs)).toEqual({
-          '24 Oct': 1,
-          '25 Oct': 1,
-          '26 Oct': 0,
-          '27 Oct': 0,
-          '28 Oct': 1,
-          '29 Oct': 0,
-          '30 Oct': 1,
-        });
+        expect(VisitorStats.calculateTimePeriodStatistics(since, until, dateRange, visitors))
+          .toEqual({
+            '24 Oct': 1,
+            '25 Oct': 1,
+            '26 Oct': 0,
+            '27 Oct': 0,
+            '28 Oct': 1,
+            '29 Oct': 0,
+            '30 Oct': 1,
+          });
       });
     });
   });

--- a/visitor-app/src/cb_admin/pages/VisitsData/__tests__/util.test.js
+++ b/visitor-app/src/cb_admin/pages/VisitsData/__tests__/util.test.js
@@ -239,7 +239,7 @@ describe('Visits Data Utilities', () => {
     });
   });
 
-  describe.only('VisitorStats', () => {
+  describe('VisitorStats', () => {
     describe('calculateGenderStatistics', () => {
       test('empty list gives empty stats object', () => {
         expect(VisitorStats.calculateGenderStatistics([])).toEqual({});

--- a/visitor-app/src/cb_admin/pages/VisitsData/data.js
+++ b/visitor-app/src/cb_admin/pages/VisitsData/data.js
@@ -1,0 +1,110 @@
+import { filter, flatten, pick } from 'ramda';
+import { CommunityBusiness, Visitors, Activities } from '../../../api';
+import { mapValues, combineValues } from '../../../util';
+import DateRanges from './dateRange';
+import { Stats, calculateStepSize, formatChartData, VisitorStats } from './util';
+import { colors } from '../../../shared/style_guide';
+
+const Colours = {
+  DOUGHNUT: [colors.highlight_primary, colors.highlight_secondary, colors.light],
+  BAR: colors.highlight_secondary,
+};
+
+
+export const getVisitsData = (filters, chartsOptions) => {
+  const { since, until } = DateRanges.toDates(filters.time);
+
+  const queryFilter = filter(Boolean, {
+    gender: filters.gender,
+    age: filters.age,
+    visitActivity: filters.activity,
+  });
+
+  return CommunityBusiness.getVisits({ since, until, filter: queryFilter })
+    .then((res) => {
+      const logs = res.data.result;
+
+      const genderStats = Stats.calculateGenderStatistics(logs);
+      const ageGroupsStats = Stats.calculateAgeGroupStatistics(logs);
+      const timeStats = Stats.calculateTimePeriodStatistics(since, until, filters.time, logs);
+      const categoriesStats = Stats.calculateCategoryStatistics(logs);
+      const activitiesStats = Stats.calculateActivityStatistics(logs);
+
+      return {
+        charts: {
+          ...chartsOptions,
+          time: { stepSize: calculateStepSize(timeStats) },
+          category: { stepSize: calculateStepSize(categoriesStats) },
+        },
+        data: {
+          time: formatChartData(timeStats, Colours.BAR),
+          gender: formatChartData(genderStats, Colours.DOUGHNUT),
+          category: formatChartData(categoriesStats, Colours.BAR),
+          activity: mapValues(x => formatChartData(x, Colours.BAR), activitiesStats),
+          age: formatChartData(ageGroupsStats, Colours.DOUGHNUT),
+        },
+      };
+    });
+};
+
+export const getVisitorData = (filters, chartsOptions) => {
+  const { since, until } = DateRanges.toDates(filters.time);
+
+  const queryFilter = filter(Boolean, {
+    gender: filters.gender,
+    age: filters.age,
+  });
+
+  const pVisitors = Visitors.get({}, { filter: queryFilter, visits: true, fields: ['id', 'name', 'gender', 'birthYear'] });
+  const pActivities = Activities.get();
+
+  return Promise.all([pVisitors, pActivities])
+    .then(([res, rActivities]) => {
+      const { result } = res.data;
+      const activities = rActivities.data.result;
+
+      const visitors = flatten(
+        result
+          .filter(visitor =>
+            visitor.visits.some(visit =>
+              new Date(visit.createdAt) >= since
+                && new Date(visit.createdAt) <= until
+                && (filters.activity ? visit.visitActivity === filters.activity : true),
+            ))
+          .map(visitor => ({
+            ...visitor,
+            ...pick(
+              ['visitActivity', 'category', 'createdAt'],
+              combineValues(
+                visitor.visits
+                  .filter(visit =>
+                    new Date(visit.createdAt) >= since
+                      && new Date(visit.createdAt) <= until
+                      && (filters.activity ? visit.visitActivity === filters.activity : true),
+                  ),
+              ),
+            ),
+          })));
+
+      const genderStats = VisitorStats.calculateGenderStatistics(visitors);
+      const ageGroupsStats = VisitorStats.calculateAgeGroupStatistics(visitors);
+      const activitiesStats = VisitorStats.calculateActivityStatistics(visitors, activities);
+      const categoriesStats = VisitorStats.calculateCategoryStatistics(visitors);
+      const timeStats = VisitorStats.calculateTimePeriodStatistics(since, until, filters.time, visitors);
+
+      return {
+        charts: {
+          ...chartsOptions,
+          time: { stepSize: calculateStepSize(timeStats) },
+          category: { stepSize: calculateStepSize(categoriesStats) },
+        },
+        data: {
+          time: formatChartData(timeStats, Colours.BAR),
+          gender: formatChartData(genderStats, Colours.DOUGHNUT),
+          category: formatChartData(categoriesStats, Colours.BAR),
+          activity: mapValues(x => formatChartData(x, Colours.BAR), activitiesStats),
+          age: formatChartData(ageGroupsStats, Colours.DOUGHNUT),
+        },
+      };
+    });
+};

--- a/visitor-app/src/cb_admin/pages/VisitsData/util.js
+++ b/visitor-app/src/cb_admin/pages/VisitsData/util.js
@@ -1,0 +1,124 @@
+import moment from 'moment';
+import { zip, identity, toPairs, head, last, map, assoc, assocPath, mergeWith, add, uniq, fromPairs, mergeDeepWith } from 'ramda';
+import { collectBy, mapValues, ones } from '../../../util';
+import { createAgeGroups } from '../../../shared/constants';
+import DateRanges, { DateRangesEnum } from './dateRange';
+
+export const AgeGroups = createAgeGroups(['0-17', '18-34', '35-50', '51-69', '70+']);
+
+// isAgeGiven :: Log -> Boolean
+const isAgeGiven = log => typeof log.birthYear === 'number';
+
+// count :: { k: [a] } -> { k: Number }
+const count = o => mapValues(xs => xs.length, o);
+
+export const Stats = {
+  // calculateGenderStatistics :: [Log] -> { k: Number }
+  calculateGenderStatistics: logs => count(collectBy(log => log.gender, logs)),
+
+  // calculateAgeGroupStatistics :: [Log] -> { k: Number }
+  calculateAgeGroupStatistics: logs =>
+    count(collectBy(
+      identity,
+      logs.filter(isAgeGiven).map(l => AgeGroups.fromBirthYear(l.birthYear)),
+    )),
+
+  // calculateCategoryStatistics :: [Log] -> { k: Number }
+  calculateCategoryStatistics: logs =>
+    count(collectBy(log => log.category, logs)),
+
+  // calculateActivityStatistics :: [Log] -> { category: { activity: Number } }
+  calculateActivityStatistics: logs =>
+    mapValues(
+      ls => count(collectBy(l => l.visitActivity, ls)),
+      collectBy(log => log.category, logs),
+    ),
+
+  // calculateTimePeriodStatistics :: [Log] -> { k: Number }
+  calculateTimePeriodStatistics: (since, until, dateRange, logs) =>
+    DateRanges.zeroPadObject(
+      since,
+      until,
+      dateRange,
+      count(collectBy(
+        identity,
+        logs.map(log =>
+          (dateRange === DateRangesEnum.LAST_MONTH
+            ? moment(log.createdAt).startOf('isoWeek')
+            : moment(log.createdAt)
+          )
+            .format(DateRanges.toFormat(dateRange))),
+      )),
+    ),
+};
+
+export const VisitorStats = {
+  // calculateGenderStatistics :: [Visitor] -> { k: Number }
+  calculateGenderStatistics: visitors => count(collectBy(log => log.gender, visitors)),
+
+  // calculateAgeGroupStatistics :: [Visitor] -> { k: Number }
+  calculateAgeGroupStatistics: visitors =>
+    count(collectBy(
+      identity,
+      visitors.filter(isAgeGiven).map(l => AgeGroups.fromBirthYear(l.birthYear)),
+    )),
+
+  // calculateCategoryStatistics :: [Visitor] -> { k: Number }
+  calculateCategoryStatistics: visitors =>
+    visitors.reduce((acc, visitor) => {
+      const cats = uniq(visitor.category);
+      const categoriesCount = fromPairs(zip(cats, ones(cats.length)));
+      return mergeWith(add, acc, categoriesCount);
+    }, {}),
+
+  // calculateActivityStatistics :: [Visitor] -> { category: { activity: Number } }
+  calculateActivityStatistics: (visitors, activities) => {
+    const activityToCategoryMap = activities
+      .reduce((acc, act) => assoc(act.name, act.category, acc), {});
+
+    return visitors.reduce((acc, visitor) => {
+      const activitiesCount = uniq(visitor.visitActivity)
+        .reduce((counts, activity) => {
+          const cat = activityToCategoryMap[activity];
+          return assocPath([cat, activity], 1, counts);
+        }, {});
+
+      return mergeDeepWith(add, acc, activitiesCount);
+    }, {});
+  },
+
+  // calculateTimePeriodStatistics :: [Visitor] -> { k: Number }
+  calculateTimePeriodStatistics: (since, until, dateRange, visitors) => {
+    const empty = DateRanges.zeroPadObject(since, until, dateRange, {});
+    const fmt = DateRanges.toFormat(dateRange);
+    return visitors.reduce((acc, visitor) => {
+      const visitorTotals = visitor.createdAt
+        .map(date =>
+          (dateRange === DateRangesEnum.LAST_MONTH
+            ? moment(date).startOf('isoWeek')
+            : moment(date)
+          ).format(fmt))
+        .reduce((counts, date) => assoc(date, date in counts ? counts[date] : 1, counts), {});
+      return mergeWith(add, acc, visitorTotals);
+    }, empty);
+  },
+};
+
+// calculateStepSize :: { k: Number } -> Number
+export const calculateStepSize = stats =>
+  Math.max(1, Math.floor(Math.max(...Object.values(stats)) / 5));
+
+// formatChartData :: ({ k: v }, [string], string?) -> { k: v }
+export const formatChartData = (data, bgColor, label) => {
+  const pairedData = toPairs(data);
+  return {
+    labels: map(head, pairedData),
+    datasets: [
+      {
+        label,
+        data: map(last, pairedData),
+        backgroundColor: bgColor,
+      },
+    ],
+  };
+};


### PR DESCRIPTION
related to #324 

### Changes
- Adds data processing functions

### Testing Requirements
N/A (test together with final PR)

### Release Requirements
N/A

### Manual Deployment
N/A

### NOTE
- In `preProcessVisitors`, the step of using `combineValues` to collect values of `visitActivity`, `createdAt`, and `category` onto the visitor object was an attempt to make the calculation of stats slightly simpler (i.e. to avoid having to iterate through the `visits` array in each `VisitorStats` function). However, it may be that this just obfuscates what's happening more than necessary (and iterating through visits won't be much slower). LMK what you think and I can get rid of this bit.