### PR TITLE
✨ add projects stats to dashboard

### DIFF
--- a/dashboard-app/src/features/dashboard/Dashboard/__tests__/index.test.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/__tests__/index.test.ts
@@ -89,4 +89,17 @@ describe('Dashboard Page', () => {
 
     await wait(() => expect(tools.history.location.pathname).toBe('/volunteers'));
   });
+
+  test('Clicking project goes to /projects', async () => {
+    expect.assertions(1);
+
+    mock.onGet('/community-businesses/me/volunteer-logs').reply(200, { result: [] });
+    mock.onGet('/community-businesses/me/volunteers').reply(200, { result: [] });
+
+    const tools = renderWithHistory(Dashboard);
+    const buttons = await waitForElement(() => tools.getAllByText('View data'));
+    fireEvent.click(buttons[3]);
+
+    await wait(() => expect(tools.history.location.pathname).toBe('/projects'));
+  });
 });

--- a/dashboard-app/src/features/dashboard/Dashboard/__tests__/useDashboardStatistics.test.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/__tests__/useDashboardStatistics.test.ts
@@ -2,7 +2,8 @@ import moment from 'moment';
 import {
   timeStatsToProps,
   volunteerStatsToProps,
-  activityStatsToProps
+  activityStatsToProps,
+  projectStatsToProps,
 } from '../useDashboardStatistics';
 
 
@@ -112,7 +113,8 @@ describe('volunteerStatsToProps', () => {
         label: '10 hours each',
         data: ['foo', 'bar'],
         limit: 3,
-        truncationString: '...', },
+        truncationString: '...',
+      },
     });
   });
 
@@ -127,7 +129,8 @@ describe('volunteerStatsToProps', () => {
         label: '10 hours each',
         data: ['foo', 'bar', 'woo'],
         limit: 3,
-        truncationString: '...', },
+        truncationString: '...',
+      },
     });
   });
 
@@ -142,7 +145,8 @@ describe('volunteerStatsToProps', () => {
         label: '10 hours each',
         data: ['foo', 'bar', 'woo', 'war'],
         limit: 3,
-        truncationString: '...', },
+        truncationString: '...',
+      },
     });
   });
 });
@@ -188,7 +192,8 @@ describe('activityStatsToProps', () => {
       },
       right: {
         label: 'hours each',
-        data: 10 },
+        data: 10
+      },
     });
   });
 
@@ -203,7 +208,8 @@ describe('activityStatsToProps', () => {
       },
       right: {
         label: 'hours each',
-        data: 10 },
+        data: 10
+      },
     });
   });
 
@@ -218,7 +224,87 @@ describe('activityStatsToProps', () => {
       },
       right: {
         label: 'hours each',
-        data: 10 },
+        data: 10
+      },
+    });
+  });
+});
+
+describe('projectStatsToProps', () => {
+  test('no arguments', () => {
+    expect(projectStatsToProps()).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: { label: 'No data available', data: [] },
+      right: { label: 'hours', data: 0 },
+    });
+  });
+
+  test('zero data points', () => {
+    expect(projectStatsToProps({ labels: [], value: 0 })).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: { label: 'No data available', data: [], limit: 2, truncationString: '...' },
+      right: { label: 'hours', data: 0 },
+    });
+  });
+
+  test('one data point', () => {
+    expect(projectStatsToProps({ labels: ['foo'], value: 10 })).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: {
+        label: 'Most popular project was',
+        data: ['foo'],
+        limit: 2,
+        truncationString: '...',
+      },
+      right: { label: 'hours', data: 10 },
+    });
+  });
+
+  test('two data points', () => {
+    expect(projectStatsToProps({ labels: ['foo', 'bar'], value: 10 })).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: {
+        label: 'Most popular projects were',
+        data: ['foo', 'bar'],
+        limit: 2,
+        truncationString: '...',
+      },
+      right: {
+        label: 'hours each',
+        data: 10
+      },
+    });
+  });
+
+  test('three data points', () => {
+    expect(projectStatsToProps({ labels: ['foo', 'bar', 'woo'], value: 10 })).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: {
+        label: 'Most popular projects were',
+        data: ['foo', 'bar', 'woo'],
+        limit: 2,
+        truncationString: '...',
+      },
+      right: {
+        label: 'hours each',
+        data: 10
+      },
+    });
+  });
+
+  test('four data points', () => {
+    expect(projectStatsToProps({ labels: ['foo', 'bar', 'woo', 'war'], value: 10 })).toEqual({
+      topText: ['During ', moment().format('MMM YYYY')],
+      left: {
+        label: 'Most popular projects were',
+        data: ['foo', 'bar', 'woo', 'war'],
+        limit: 2,
+        truncationString: '...',
+      },
+      right: {
+        label: 'hours each',
+        data: 10
+      },
     });
   });
 });

--- a/dashboard-app/src/features/dashboard/Dashboard/__tests__/util.test.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/__tests__/util.test.ts
@@ -28,17 +28,17 @@ describe('Dashboard statistics utilities', () => {
     });
 
     test('single entry is returned as only max', () => {
-      expect(findMostActive({ ['Jun 2018']: [{ duration: { minutes: 125 } }] }))
+      expect(findMostActive({ 'Jun 2018': [{ duration: { minutes: 125 } }] }))
         .toEqual({ labels: ['Jun 2018'], value: 2 }); // rounded
     });
 
     test('multiple equal entries are all returned', () => {
       const logs = {
-        ['Sept 2018']: [
+        'Sept 2018': [
           { duration: { hours: 1, minutes: 50 } },
           { duration: { hours: 1 } },
         ],
-        ['Jun 2018']: [
+        'Jun 2018': [
           { duration: { hours: 2, minutes: 20 } },
           { duration: { minutes: 30 } },
         ],
@@ -52,15 +52,15 @@ describe('Dashboard statistics utilities', () => {
 
     test('multiple different entries -- only max is returned', () => {
       const logs = {
-        ['Sept 2018']: [
+        'Sept 2018': [
           { duration: { hours: 0.5, minutes: 50 } },
           { duration: { hours: 1 } },
         ],
-        ['Jun 2018']: [
+        'Jun 2018': [
           { duration: { hours: 2, minutes: 20 } },
           { duration: { minutes: 30 } },
         ],
-        ['Jan 2019']: [
+        'Jan 2019': [
           { duration: { hours: 1 } },
           { duration: { minutes: 10 } },
         ],
@@ -74,15 +74,15 @@ describe('Dashboard statistics utilities', () => {
 
     test('mix of equal and non-equal entries -- only max are returned', () => {
       const logs = {
-        ['Sept 2018']: [
+        'Sept 2018': [
           { duration: { hours: 1, minutes: 50 } },
           { duration: { hours: 1 } },
         ],
-        ['Jun 2018']: [
+        'Jun 2018': [
           { duration: { hours: 2, minutes: 20 } },
           { duration: { minutes: 30 } },
         ],
-        ['Jan 2019']: [
+        'Jan 2019': [
           { duration: { hours: 1 } },
           { duration: { minutes: 10 } },
         ],
@@ -96,15 +96,15 @@ describe('Dashboard statistics utilities', () => {
 
     test('non-date labels are sorted alphabetically', () => {
       const logs = {
-        ['Toad']: [
+        'Toad': [
           { duration: { hours: 1, minutes: 50 } },
           { duration: { hours: 1 } },
         ],
-        ['Badger']: [
+        'Badger': [
           { duration: { hours: 2, minutes: 20 } },
           { duration: { minutes: 30 } },
         ],
-        ['Mole']: [
+        'Mole': [
           { duration: { hours: 1 } },
           { duration: { minutes: 10 } },
         ],

--- a/dashboard-app/src/features/dashboard/Dashboard/index.tsx
+++ b/dashboard-app/src/features/dashboard/Dashboard/index.tsx
@@ -11,6 +11,7 @@ import useDashboardStatistics, {
   activityStatsToProps,
   timeStatsToProps,
   volunteerStatsToProps,
+  projectStatsToProps,
 } from './useDashboardStatistics';
 import {
   RedirectHttpErrorBoundary,
@@ -37,6 +38,10 @@ const TimeTile: React.FC<{ stats: any }> = ({ stats }) => (
 
 const ActivityTile: React.FC<{ stats: any }> = ({ stats }) => (
   stats && <NumberDataCard {...activityStatsToProps(stats)} />
+);
+
+const ProjectTile: React.FC<{ stats: any }> = ({ stats }) => (
+  stats && <NumberDataCard {...projectStatsToProps(stats)} />
 );
 
 const Dashboard: React.FunctionComponent<RouteComponentProps> = (props) => {
@@ -99,7 +104,11 @@ const Dashboard: React.FunctionComponent<RouteComponentProps> = (props) => {
                   callToAction="View data"
                   placeHolder="P"
                   onClick={() => Pages.navigateTo('Projects', props.history.push)}
-                />
+                >
+                  <RenderErrorBoundary>
+                    <ProjectTile stats={data && data.projectStats} />
+                  </RenderErrorBoundary>
+                </Polaroid>
               </Col>
             </Row>
           </Col>

--- a/dashboard-app/src/features/dashboard/Dashboard/useDashboardStatistics.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/useDashboardStatistics.ts
@@ -21,6 +21,7 @@ export default () => {
   const [timeStats, setTimeStats] = useState<EqualDataPoints>({ labels: [], value: 0 });
   const [volunteerStats, setVolunteerStats] = useState<EqualDataPoints>({ labels: [], value: 0 });
   const [activityStats, setActivityStats] = useState<EqualDataPoints>({ labels: [], value: 0 });
+  const [projectStats, setProjectStats] = useState<EqualDataPoints>({ labels: [], value: 0 });
 
   const {
     loading,
@@ -77,6 +78,13 @@ export default () => {
       )
     );
 
+    // most active projects (current month)
+    setProjectStats(
+      findMostActive(
+        collectBy((log) => log.project || 'General', monthLogs)
+      )
+    );
+
     // most active volunteers (current month)
     setVolunteerStats(
       findMostActive(
@@ -103,6 +111,7 @@ export default () => {
         timeStats,
         activityStats,
         volunteerStats,
+        projectStats,
       },
     };
 
@@ -213,6 +222,45 @@ export const timeStatsToProps = (pts?: EqualDataPoints): NumberTileProps => {
       label: leftLabel,
       data: pts.labels,
       limit: 3,
+      truncationString: '...',
+    },
+    right: {
+      label: rightLabel,
+      data: pts.value,
+    },
+  };
+};
+
+export const projectStatsToProps = (pts?: EqualDataPoints): NumberTileProps => {
+  if (!pts) {
+    return {
+      topText: ['During ', getCurrentMonth()],
+      left: {
+        label: 'No data available',
+        data: [],
+      },
+      right: {
+        label: 'hours',
+        data: 0,
+      },
+    };
+  }
+
+
+  const leftLabel = pts.labels.length > 1
+    ? 'Most popular projects were'
+    : pts.labels.length === 1
+      ? 'Most popular project was'
+      : 'No data available';
+
+  const rightLabel = `hours${pts.labels.length > 1 ? ' each' : ''}`;
+
+  return {
+    topText: ['During ', getCurrentMonth()],
+    left: {
+      label: leftLabel,
+      data: pts.labels,
+      limit: 2,
       truncationString: '...',
     },
     right: {

--- a/lib/twine-util/package.json
+++ b/lib/twine-util/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "jest",
     "cover": "jest --coverage",
-    "build": "tsc",
+    "build": "tsc --build tsconfig.production.json",
     "lint": "eslint *.ts",
     "postinstall": "npm run build"
   },

--- a/lib/twine-util/tsconfig.json
+++ b/lib/twine-util/tsconfig.json
@@ -7,7 +7,9 @@
     "removeComments": false,
     "preserveConstEnums": true,
     "sourceMap": true,
-    "lib": ["es2017"],
+    "lib": [
+      "es2017"
+    ],
     "declaration": true,
   }
 }

--- a/lib/twine-util/tsconfig.production.json
+++ b/lib/twine-util/tsconfig.production.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "__tests__"
+  ]
+}


### PR DESCRIPTION
related to #335

### Changes
- Add projects stats to tile on dashboard landing page

### Testing Requirements
- [x] Dashboard
  - Log in as account with logs in the past month -- see stats showing most popular project
  - Log in as account with no logs in the past month -- see "no data available"

### Release Requirements
- On PO approval, with the rest of the projects changes

### Manual Deployment
- Dashboard