### PR TITLE
🔎 expose visitor search endpoint

### DIFF
--- a/api/docs/public_api.md
+++ b/api/docs/public_api.md
@@ -15,7 +15,7 @@ The endpoints of the API that are made public are documented below.
   - [GET /v1/community-businesses/me/visit-activities](#get-v1community-businessesmevisit-activities)
   - [GET /v1/community-businesses/me/visit-logs](#get-v1community-businessesmevisit-logs)
   - [GET /v1/community-businesses/me/visit-logs/aggregates](#get-v1community-businessesmevisit-logsaggregates)
-
+  - [POST /v1/users/visitors/search](#post-v1usersvisitorssearch)
 
 ## Common query parameters
 The API supports objects and arrays in query strings, encoded and parsed by the [qs](https://npmjs.com/package/qs) module (e.g. `?array[0]=foo&array[1]=bar` is parsed to `array=['foo', 'bar']`). See the qs module's documentation for more examples.
@@ -127,3 +127,9 @@ Query parameters:
   - `age`: [integer, integer] -- age limits, min to max
   - `visitActivity`: string -- filter on visit activity name
   - `gender`: male | female | prefer not to say
+
+### POST /v1/users/visitors/search
+Query parameters: **None**
+
+Payload parameters:
+- `qrCode`: Hash string encoded in scanned QR Code

--- a/api/src/api/v1/users/visitors/search.ts
+++ b/api/src/api/v1/users/visitors/search.ts
@@ -13,8 +13,10 @@ const routes: [Api.Users.Visitors.Search.POST.Route] = [
     options: {
       description: 'Search for visitors using their QR code',
       auth: {
-        strategy: 'standard',
-        scope: ['user_details-child:read'],
+        strategies: ['standard', 'external'],
+        access: {
+          scope: ['user_details-child:read', 'api:visitor:read'],
+        },
       },
       validate: {
         payload: {


### PR DESCRIPTION
fixes #384 

### Changes
- Expose `POST /v1/users/visitors/search` endpoint to external users via `external` auth strategy
- Update public API docs

### Testing Requirements
- [x] API
  - Send valid QR code hash to endpoint using API token (expect visitor object)
  - Send invalid QR code hash to endpoint using API token (expect null)

### Release Requirements
- Anytime

### Manual Deployment
- API