### PR TITLE
🐛 fix no data overlay text on dashboard

### DIFF
--- a/dashboard-app/src/features/dashboard/components/StackedBarChart/index.tsx
+++ b/dashboard-app/src/features/dashboard/components/StackedBarChart/index.tsx
@@ -18,6 +18,7 @@ import Chart from './Chart';
 import { LegendData } from './types';
 import { TitleString } from '../Title';
 import { DashboardContext } from '../../context';
+import { TableTypeItem } from '../../dataManipulation/tableType';
 
 
 /*
@@ -41,10 +42,24 @@ interface Props {
 const isCellDurationZero = (content: string | Duration.Duration) =>
   typeof content === 'object' ? Duration.equals(content, {}) : true;
 
+const getNoActiveLegendText = (s: TableTypeItem['groupByX']) => {
+  switch (s) {
+    case 'Activity':
+      return 'Select an activity to show data';
+
+    case 'Volunteer Name':
+      return 'Select volunteers to show their hours';
+
+    case 'Project':
+      return 'Select projects to show data';
+
+    default:
+      return 'Select legend items to show data';
+  }
+}
+
 const getOverlayText = (data: AggregatedData, legendItemsActive: boolean): [boolean, string] => {
-  const noActiveLegendText = data.groupByX === 'Activity'
-    ? 'Select an activity to show data'
-    : 'Select volunteers to show their hours';
+  const noActiveLegendText = getNoActiveLegendText(data.groupByX);
 
   const noData = data.rows.length === 0 || data.rows
     .every((row) => reduceValues((acc, content) => acc && isCellDurationZero(content), true, row))

--- a/dashboard-app/src/features/dashboard/dataManipulation/logsToAggregatedData.ts
+++ b/dashboard-app/src/features/dashboard/dataManipulation/logsToAggregatedData.ts
@@ -19,8 +19,8 @@ interface Params {
 
 export type Row = Dictionary<string | Duration.Duration>;
 export interface AggregatedData {
-  groupByX: string;
-  groupByY: string;
+  groupByX: TableTypeItem['groupByX'];
+  groupByY: TableTypeItem['groupByY'];
   rows: Row[];
 }
 

--- a/dashboard-app/src/features/dashboard/dataManipulation/tableType.ts
+++ b/dashboard-app/src/features/dashboard/dataManipulation/tableType.ts
@@ -2,8 +2,8 @@ import moment from 'moment';
 import Months from '../../../lib/util/months';
 
 export interface TableTypeItem {
-  groupByX: string;
-  groupByY: string;
+  groupByX: 'Volunteer Name' | 'Activity' | 'Project';
+  groupByY: 'Activity' | 'Month' | 'Project';
   xIdFromLogs: 'userId' | 'activity' | 'project';
   getYIdFromLogs: (x: any) => string;
 }


### PR DESCRIPTION
### Changes
- Make `groupByX` and `groupByY` types narrower
- Expand the cases considered when inferring overlay text from `groupByX` value

### Testing Requirements
- [x] Dashboard
  - Deselect all legend values on all pages (expect message to be appropriate to data that would be displayed)

### Release Requirements
- With rest of feature branch

### Manual Deployment
- Dashboard
