### PR TITLE
🧩 expand gender options in validation schema

### DIFF
--- a/api/database/migrations/20200106_new_gender_options.ts
+++ b/api/database/migrations/20200106_new_gender_options.ts
@@ -1,0 +1,3 @@
+import { buildQueryFromFile } from '../utils';
+exports.up = buildQueryFromFile(__filename);
+exports.down = () => {};

--- a/api/database/migrations/sql/20200106_new_gender_options.sql
+++ b/api/database/migrations/sql/20200106_new_gender_options.sql
@@ -1,0 +1,5 @@
+/*
+ * Migration template
+ */
+
+ insert into gender (gender_name) values ('non-binary'), ('intersex'), ('other');

--- a/api/src/api/v1/schema/request.ts
+++ b/api/src/api/v1/schema/request.ts
@@ -87,7 +87,7 @@ export const query: Record<keyof ApiRequestQuery, Joi.Schema> = {
  * Commonly used payload schema
  */
 export const gender =
-  Joi.string().only(['male', 'female', 'prefer not to say']);
+  Joi.string().only(['male', 'female', 'prefer not to say', 'non-binary', 'intersex', 'other']);
 
 export const id =
   Joi.number().integer().positive();


### PR DESCRIPTION
related to #409 

### Changes
- Adds items detailed in #409 to list of permitted gender options for API payloads

### Testing Requirements
- [x] API
  - Send `POST /v1/users/register/visitors` with one of the new gender options
  - Expect 200

### Release Requirements
- When ready, no PO approval required

### Manual Deployment
- API
- After deployment, add new gender options to the database with:
```sql
insert into gender (gender_name) values ('non-binary'), ('intersex'), ('other');
```
