### PR TITLE
📊 Update time-frames on dashboard stats

### DIFF
--- a/dashboard-app/src/features/dashboard/Dashboard/__tests__/useDashboardStatistics.test.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/__tests__/useDashboardStatistics.test.ts
@@ -10,7 +10,10 @@ import {
 describe('timeStatsToProps', () => {
   test('no arguments', () => {
     expect(timeStatsToProps()).toEqual({
-      topText: ['Over the past ', '12 months'],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: { label: 'No data available', data: [] },
       right: { label: 'hours', data: 0 },
     });
@@ -18,15 +21,21 @@ describe('timeStatsToProps', () => {
 
   test('zero data points', () => {
     expect(timeStatsToProps({ labels: [], value: 0 })).toEqual({
-      topText: ['Over the past ', '12 months'],
-      left: { label: 'No data available', data: [], limit: 3, truncationString: '...' },
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
+      left: { label: 'No data available', data: [] },
       right: { label: 'hours', data: 0 },
     });
   });
 
   test('one data point', () => {
     expect(timeStatsToProps({ labels: ['foo'], value: 10 })).toEqual({
-      topText: ['Over the past ', '12 months'],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: {
         label: 'Most volunteer days were in',
         data: ['foo'],
@@ -39,7 +48,10 @@ describe('timeStatsToProps', () => {
 
   test('two data points', () => {
     expect(timeStatsToProps({ labels: ['foo', 'bar'], value: 10 })).toEqual({
-      topText: ['Over the past ', '12 months'],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: {
         label: 'Most volunteer days were in',
         data: ['foo', 'bar'],
@@ -52,7 +64,10 @@ describe('timeStatsToProps', () => {
 
   test('three data points', () => {
     expect(timeStatsToProps({ labels: ['foo', 'bar', 'woo'], value: 10 })).toEqual({
-      topText: ['Over the past ', '12 months'],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: {
         label: 'Most volunteer days were in',
         data: ['foo', 'bar', 'woo'],
@@ -65,7 +80,10 @@ describe('timeStatsToProps', () => {
 
   test('four data points', () => {
     expect(timeStatsToProps({ labels: ['foo', 'bar', 'woo', 'war'], value: 10 })).toEqual({
-      topText: ['Over the past ', '12 months'],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: {
         label: 'Most volunteer days were in',
         data: ['foo', 'bar', 'woo', 'war'],
@@ -80,7 +98,10 @@ describe('timeStatsToProps', () => {
 describe('volunteerStatsToProps', () => {
   test('no arguments', () => {
     expect(volunteerStatsToProps()).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: { label: 'No data available', data: [] },
       right: { label: '0 hours', data: [] },
     });
@@ -88,15 +109,21 @@ describe('volunteerStatsToProps', () => {
 
   test('zero data points', () => {
     expect(volunteerStatsToProps({ labels: [], value: 0 })).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: { label: 'No data available', data: [] },
-      right: { label: '0 hours', data: [], limit: 3, truncationString: '...' },
+      right: { label: '0 hours', data: [] },
     });
   });
 
   test('one data point', () => {
     expect(volunteerStatsToProps({ labels: ['foo'], value: 10 })).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: { label: 'Top volunteer', data: [] },
       right: { label: '10 hours', data: ['foo'], limit: 3, truncationString: '...' },
     });
@@ -104,7 +131,10 @@ describe('volunteerStatsToProps', () => {
 
   test('two data points', () => {
     expect(volunteerStatsToProps({ labels: ['foo', 'bar'], value: 10 })).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: {
         label: 'Top volunteers',
         data: [],
@@ -120,7 +150,10 @@ describe('volunteerStatsToProps', () => {
 
   test('three data points', () => {
     expect(volunteerStatsToProps({ labels: ['foo', 'bar', 'woo'], value: 10 })).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: {
         label: 'Top volunteers',
         data: [],
@@ -136,7 +169,10 @@ describe('volunteerStatsToProps', () => {
 
   test('four data points', () => {
     expect(volunteerStatsToProps({ labels: ['foo', 'bar', 'woo', 'war'], value: 10 })).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: {
         label: 'Top volunteers',
         data: [],
@@ -154,7 +190,10 @@ describe('volunteerStatsToProps', () => {
 describe('activityStatsToProps', () => {
   test('no arguments', () => {
     expect(activityStatsToProps()).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: { label: 'No data available', data: [] },
       right: { label: 'hours', data: 0 },
     });
@@ -162,15 +201,21 @@ describe('activityStatsToProps', () => {
 
   test('zero data points', () => {
     expect(activityStatsToProps({ labels: [], value: 0 })).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
-      left: { label: 'No data available', data: [], limit: 2, truncationString: '...' },
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
+      left: { label: 'No data available', data: [] },
       right: { label: 'hours', data: 0 },
     });
   });
 
   test('one data point', () => {
     expect(activityStatsToProps({ labels: ['foo'], value: 10 })).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: {
         label: 'Most popular activity was',
         data: ['foo'],
@@ -183,7 +228,10 @@ describe('activityStatsToProps', () => {
 
   test('two data points', () => {
     expect(activityStatsToProps({ labels: ['foo', 'bar'], value: 10 })).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: {
         label: 'Most popular activities were',
         data: ['foo', 'bar'],
@@ -199,7 +247,10 @@ describe('activityStatsToProps', () => {
 
   test('three data points', () => {
     expect(activityStatsToProps({ labels: ['foo', 'bar', 'woo'], value: 10 })).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: {
         label: 'Most popular activities were',
         data: ['foo', 'bar', 'woo'],
@@ -215,7 +266,10 @@ describe('activityStatsToProps', () => {
 
   test('four data points', () => {
     expect(activityStatsToProps({ labels: ['foo', 'bar', 'woo', 'war'], value: 10 })).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: {
         label: 'Most popular activities were',
         data: ['foo', 'bar', 'woo', 'war'],
@@ -233,7 +287,10 @@ describe('activityStatsToProps', () => {
 describe('projectStatsToProps', () => {
   test('no arguments', () => {
     expect(projectStatsToProps()).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: { label: 'No data available', data: [] },
       right: { label: 'hours', data: 0 },
     });
@@ -241,15 +298,21 @@ describe('projectStatsToProps', () => {
 
   test('zero data points', () => {
     expect(projectStatsToProps({ labels: [], value: 0 })).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
-      left: { label: 'No data available', data: [], limit: 2, truncationString: '...' },
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
+      left: { label: 'No data available', data: [] },
       right: { label: 'hours', data: 0 },
     });
   });
 
   test('one data point', () => {
     expect(projectStatsToProps({ labels: ['foo'], value: 10 })).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: {
         label: 'Most popular project was',
         data: ['foo'],
@@ -262,7 +325,10 @@ describe('projectStatsToProps', () => {
 
   test('two data points', () => {
     expect(projectStatsToProps({ labels: ['foo', 'bar'], value: 10 })).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: {
         label: 'Most popular projects were',
         data: ['foo', 'bar'],
@@ -278,7 +344,10 @@ describe('projectStatsToProps', () => {
 
   test('three data points', () => {
     expect(projectStatsToProps({ labels: ['foo', 'bar', 'woo'], value: 10 })).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: {
         label: 'Most popular projects were',
         data: ['foo', 'bar', 'woo'],
@@ -294,7 +363,10 @@ describe('projectStatsToProps', () => {
 
   test('four data points', () => {
     expect(projectStatsToProps({ labels: ['foo', 'bar', 'woo', 'war'], value: 10 })).toEqual({
-      topText: ['During ', moment().format('MMM YYYY')],
+      topText: [
+        'Between ',
+        `${moment().subtract(3, 'months').format('DD MMM YYYY')} - ${moment().format('DD MMM YYYY')}`
+      ],
       left: {
         label: 'Most popular projects were',
         data: ['foo', 'bar', 'woo', 'war'],

--- a/dashboard-app/src/features/dashboard/Dashboard/useDashboardStatistics.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/useDashboardStatistics.ts
@@ -14,9 +14,19 @@ export type EqualDataPoints = {
 };
 
 
+const getDateLimits = () => [
+  moment().subtract(3, 'months'),
+  moment(),
+];
+
+const getFormattedDateLimits = () =>
+  getDateLimits()
+    .map((d) => d.format('DD MMM YYYY'))
+    .join(' - ');
+
+
 export default () => {
-  const threeMonthsAgo = moment().subtract(3, 'months').toDate();
-  const now = moment().toDate();
+  const [threeMonthsAgo, now] = getDateLimits().map((d) => d.toDate());
 
   const [timeStats, setTimeStats] = useState<EqualDataPoints>({ labels: [], value: 0 });
   const [volunteerStats, setVolunteerStats] = useState<EqualDataPoints>({ labels: [], value: 0 });
@@ -113,18 +123,11 @@ export default () => {
   }
 };
 
-const getCurrentMonth = () =>
-  [
-    moment().subtract(3, 'months'),
-    moment(),
-  ]
-    .map((d) => d.format('DD MMM YYYY'))
-    .join(' - ');
 
 export const activityStatsToProps = (pts?: EqualDataPoints): NumberTileProps => {
   if (!pts || pts.value === 0) {
     return {
-      topText: ['Between ', getCurrentMonth()],
+      topText: ['Between ', getFormattedDateLimits()],
       left: {
         label: 'No data available',
         data: [],
@@ -144,7 +147,7 @@ export const activityStatsToProps = (pts?: EqualDataPoints): NumberTileProps => 
   const rightLabel = `hours${pts.labels.length > 1 ? ' each' : ''}`;
 
   return {
-    topText: ['Between ', getCurrentMonth()],
+    topText: ['Between ', getFormattedDateLimits()],
     left: {
       label: leftLabel,
       data: pts.labels,
@@ -162,7 +165,7 @@ export const activityStatsToProps = (pts?: EqualDataPoints): NumberTileProps => 
 export const volunteerStatsToProps = (pts?: EqualDataPoints): TextTileProps => {
   if (!pts || pts.value === 0) {
     return {
-      topText: ['Between ', getCurrentMonth()],
+      topText: ['Between ', getFormattedDateLimits()],
       left: {
         label: 'No data available',
         data: [],
@@ -182,7 +185,7 @@ export const volunteerStatsToProps = (pts?: EqualDataPoints): TextTileProps => {
   const rightLabel = `${pts.value} hours${pts.labels.length > 1 ? ' each' : ''}`;
 
   return {
-    topText: ['Between ', getCurrentMonth()],
+    topText: ['Between ', getFormattedDateLimits()],
     left: {
       label: leftLabel,
       data: [],
@@ -200,7 +203,7 @@ export const volunteerStatsToProps = (pts?: EqualDataPoints): TextTileProps => {
 export const timeStatsToProps = (pts?: EqualDataPoints): NumberTileProps => {
   if (!pts || pts.value === 0) {
     return {
-      topText: ['Between ', getCurrentMonth()],
+      topText: ['Between ', getFormattedDateLimits()],
       left: {
         label: 'No data available',
         data: [],
@@ -218,7 +221,7 @@ export const timeStatsToProps = (pts?: EqualDataPoints): NumberTileProps => {
   const rightLabel = `hours${pts.labels.length > 1 ? ' each' : ''}`;
 
   return {
-    topText: ['Between ', getCurrentMonth()],
+    topText: ['Between ', getFormattedDateLimits()],
     left: {
       label: leftLabel,
       data: pts.labels,
@@ -235,7 +238,7 @@ export const timeStatsToProps = (pts?: EqualDataPoints): NumberTileProps => {
 export const projectStatsToProps = (pts?: EqualDataPoints): NumberTileProps => {
   if (!pts || pts.value === 0) {
     return {
-      topText: ['Between ', getCurrentMonth()],
+      topText: ['Between ', getFormattedDateLimits()],
       left: {
         label: 'No data available',
         data: [],
@@ -257,7 +260,7 @@ export const projectStatsToProps = (pts?: EqualDataPoints): NumberTileProps => {
   const rightLabel = `hours${pts.labels.length > 1 ? ' each' : ''}`;
 
   return {
-    topText: ['Between ', getCurrentMonth()],
+    topText: ['Between ', getFormattedDateLimits()],
     left: {
       label: leftLabel,
       data: pts.labels,

--- a/dashboard-app/src/features/dashboard/Dashboard/useDashboardStatistics.ts
+++ b/dashboard-app/src/features/dashboard/Dashboard/useDashboardStatistics.ts
@@ -9,13 +9,13 @@ import Months from '../../../lib/util/months';
 
 
 export type EqualDataPoints = {
-  labels: string[]
-  value: number
+  labels: string[];
+  value: number;
 };
 
 
 export default () => {
-  const oneYearAgo = moment().subtract(1, 'year').toDate();
+  const threeMonthsAgo = moment().subtract(3, 'months').toDate();
   const now = moment().toDate();
 
   const [timeStats, setTimeStats] = useState<EqualDataPoints>({ labels: [], value: 0 });
@@ -31,7 +31,7 @@ export default () => {
     requests: [
       {
         ...CommunityBusinesses.configs.getLogs,
-        params: { since: oneYearAgo, until: now },
+        params: { since: threeMonthsAgo, until: now },
         transformResponse: [(res: any) => res.result],
       },
       {
@@ -49,9 +49,6 @@ export default () => {
       return;
     }
 
-    const startOfThisMonth = moment().startOf('month');
-    const endOfThisMonth = moment().endOf('month');
-
     // NOTE: Should use `VolunteerLog` types instead of `any`
     const logs: any[] = logsData.data;
     const volunteers: any[] = volunteersData.data;
@@ -61,34 +58,32 @@ export default () => {
       volunteers,
       (log, volunteer) => log.userId === volunteer.id
     );
-    const monthLogs = fullLogs.filter((log) =>
-      moment(log.startedAt).isBetween(startOfThisMonth, endOfThisMonth));
 
-    // most active months (12 months)
+    // most active months (3 months)
     setTimeStats(
       findMostActive(
         collectBy((log) => moment(log.startedAt).format(Months.format.abbreviated), fullLogs)
       )
     );
 
-    // most active activities (current month)
+    // most active activities (3 months)
     setActivityStats(
       findMostActive(
-        collectBy((log) => log.activity, monthLogs)
+        collectBy((log) => log.activity, fullLogs)
       )
     );
 
-    // most active projects (current month)
+    // most active projects (3 months)
     setProjectStats(
       findMostActive(
-        collectBy((log) => log.project || 'General', monthLogs)
+        collectBy((log) => log.project || 'General', fullLogs)
       )
     );
 
-    // most active volunteers (current month)
+    // most active volunteers (3 months)
     setVolunteerStats(
       findMostActive(
-        collectBy((log) => log.name, monthLogs)
+        collectBy((log) => log.name, fullLogs)
       )
     );
   }, [error, loading, logsData, volunteersData]);
@@ -118,12 +113,18 @@ export default () => {
   }
 };
 
-const getCurrentMonth = () => moment().format(Months.format.abbreviated);
+const getCurrentMonth = () =>
+  [
+    moment().subtract(3, 'months'),
+    moment(),
+  ]
+    .map((d) => d.format('DD MMM YYYY'))
+    .join(' - ');
 
 export const activityStatsToProps = (pts?: EqualDataPoints): NumberTileProps => {
-  if (!pts) {
+  if (!pts || pts.value === 0) {
     return {
-      topText: ['During ', getCurrentMonth()],
+      topText: ['Between ', getCurrentMonth()],
       left: {
         label: 'No data available',
         data: [],
@@ -143,7 +144,7 @@ export const activityStatsToProps = (pts?: EqualDataPoints): NumberTileProps => 
   const rightLabel = `hours${pts.labels.length > 1 ? ' each' : ''}`;
 
   return {
-    topText: ['During ', getCurrentMonth()],
+    topText: ['Between ', getCurrentMonth()],
     left: {
       label: leftLabel,
       data: pts.labels,
@@ -159,9 +160,9 @@ export const activityStatsToProps = (pts?: EqualDataPoints): NumberTileProps => 
 
 
 export const volunteerStatsToProps = (pts?: EqualDataPoints): TextTileProps => {
-  if (!pts) {
+  if (!pts || pts.value === 0) {
     return {
-      topText: ['During ', getCurrentMonth()],
+      topText: ['Between ', getCurrentMonth()],
       left: {
         label: 'No data available',
         data: [],
@@ -181,7 +182,7 @@ export const volunteerStatsToProps = (pts?: EqualDataPoints): TextTileProps => {
   const rightLabel = `${pts.value} hours${pts.labels.length > 1 ? ' each' : ''}`;
 
   return {
-    topText: ['During ', getCurrentMonth()],
+    topText: ['Between ', getCurrentMonth()],
     left: {
       label: leftLabel,
       data: [],
@@ -197,9 +198,9 @@ export const volunteerStatsToProps = (pts?: EqualDataPoints): TextTileProps => {
 
 
 export const timeStatsToProps = (pts?: EqualDataPoints): NumberTileProps => {
-  if (!pts) {
+  if (!pts || pts.value === 0) {
     return {
-      topText: ['Over the past ', '12 months'],
+      topText: ['Between ', getCurrentMonth()],
       left: {
         label: 'No data available',
         data: [],
@@ -217,7 +218,7 @@ export const timeStatsToProps = (pts?: EqualDataPoints): NumberTileProps => {
   const rightLabel = `hours${pts.labels.length > 1 ? ' each' : ''}`;
 
   return {
-    topText: ['Over the past ', '12 months'],
+    topText: ['Between ', getCurrentMonth()],
     left: {
       label: leftLabel,
       data: pts.labels,
@@ -232,9 +233,9 @@ export const timeStatsToProps = (pts?: EqualDataPoints): NumberTileProps => {
 };
 
 export const projectStatsToProps = (pts?: EqualDataPoints): NumberTileProps => {
-  if (!pts) {
+  if (!pts || pts.value === 0) {
     return {
-      topText: ['During ', getCurrentMonth()],
+      topText: ['Between ', getCurrentMonth()],
       left: {
         label: 'No data available',
         data: [],
@@ -256,7 +257,7 @@ export const projectStatsToProps = (pts?: EqualDataPoints): NumberTileProps => {
   const rightLabel = `hours${pts.labels.length > 1 ? ' each' : ''}`;
 
   return {
-    topText: ['During ', getCurrentMonth()],
+    topText: ['Between ', getCurrentMonth()],
     left: {
       label: leftLabel,
       data: pts.labels,


### PR DESCRIPTION
fixes #416 

### Changes
- Update dasboard statistics to be calculated over the preceding quarter.
- Update copy to read e.g. `"Between 16 Sep 2019 - 16 Dec 2019"`
- Update tests

### Testing Requirements
- [ ] Dashboard
  - Check date range copy reflects the past 3 months
  - Check statistics are calculated based on last 3 months worth of data

### Release Requirements
- Together with rest of stuff on feature branch

### Manual Deployment
- Dashboard